### PR TITLE
bug(db initialisation) use an url to initialise the database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,5 @@
 NODE_ENV=development
 JWT_STRING=anyrandomstring
-DB_USERNAME=username_of_db
-DB_PASSWORD=database_password
-DB_NAME=name_of_db
-DB_HOST=host_of_db
 DB_DIALECT=postgres
 DOC_HOST=documentation_home
+DB_URL=url of db

--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@ NODE_ENV=development
 JWT_STRING=anyrandomstring
 DB_DIALECT=postgres
 DOC_HOST=documentation_home
-DB_URL=url of db
+DB_URL=postgres://username:password@host:port/db_name
+DATABASE_URL=postgres://username:password@staging_host:port/staging_db_name

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following should be installed in your machine
 * Clone this Repo and `cd` into it
 * Install all the dependancies by running the `npm install` command (or `yarn install` if you prefer)
 * Create a `.env` file and use `.env.example` as a guide on the environment variables required
+* Run `npm run migrations` to setup the database tables.
 * Start the application by running the `npm start` command(`npm start:dev` for 'watch' mode. You can also use `yarn` if you prefer)
 
 ## How To Test The Application

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start:dev": "nodemon ./server/index --exec babel-node --watch ./server",
     "build": "babel ./server -d ./build",
     "test": "mocha --recursive test/* --compilers js:babel-core/register --timeout 10000",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "migrations": "sequelize db:migrate"
   },
   "repository": {
     "type": "git",

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -3,10 +3,7 @@ const dotenv = require('dotenv');
 dotenv.config();
 
 const baseConfig = {
-  username: process.env.DB_USERNAME,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_NAME,
-  host: process.env.DB_HOST,
+  url: process.env.DB_URL,
   dialect: process.env.DB_DIALECT,
   jwtString: process.env.JWT_STRING,
 };
@@ -14,9 +11,9 @@ const baseConfig = {
 module.exports = {
   development: Object.assign(baseConfig, {}),
   test: Object.assign(baseConfig, {
-    database: process.env.DB_TEST_NAME,
+    database: process.env.DB_TEST_URL,
   }),
   production: Object.assign(baseConfig, {
-    url: process.env.DATABASE_URL,
+    url: process.env.DB_URL,
   }),
 };

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -11,7 +11,10 @@ const baseConfig = {
 module.exports = {
   development: Object.assign(baseConfig, {}),
   test: Object.assign(baseConfig, {
-    database: process.env.DB_TEST_URL,
+    url: process.env.DB_TEST_URL,
+  }),
+  staging: Object.assign(baseConfig, {
+    url: process.env.DATABASE_URL,
   }),
   production: Object.assign(baseConfig, {
     url: process.env.DB_URL,

--- a/server/index.js
+++ b/server/index.js
@@ -4,8 +4,6 @@ import bodyParser from 'body-parser';
 import swaggerUi from 'swagger-ui-express';
 import swaggerConfig from '../docs/swagger';
 
-import models from './models';
-
 // Set up the express app
 const app = express();
 
@@ -25,10 +23,8 @@ app.get('*', (req, res) => res.status(200).send({
 const port = parseInt(process.env.PORT, 10) || 8000;
 app.set('port', port);
 
-models.sequelize.sync().then(() => {
-  app.listen(port, () => {
-    console.log(`App listening on port ${app.get('port')}`);
-  });
+app.listen(port, () => {
+  console.log(`App listening on port ${app.get('port')}`);
 });
 
 export default app;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -5,19 +5,13 @@ import configObject from '../config/config';
 const env = process.env.NODE_ENV || 'development';
 const config = configObject[env];
 
-let sequelize;
-if (config.url) {
-  sequelize = new Sequelize(config.url, { });
-} else {
-  sequelize = new Sequelize(config.database, config.username, config.password, {
-    dialect: 'postgres',
-    host: config.host || '127.0.0.1',
-    define: {
-      underscored: true,
-    },
-    logging: false,
-  });
-}
+const sequelize = new Sequelize(config.url, {
+  host: config.host || '127.0.0.1',
+  define: {
+    underscored: true,
+  },
+  logging: false,
+});
 
 const db = {
   User: sequelize.import('./user'),

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -6,7 +6,6 @@ const env = process.env.NODE_ENV || 'development';
 const config = configObject[env];
 
 const sequelize = new Sequelize(config.url, {
-  host: config.host || '127.0.0.1',
   define: {
     underscored: true,
   },


### PR DESCRIPTION
Currently to create a database and run migrations, one has to define the
database name, host, password and username in the environment. This
commit fixes this by allowing the database to be initialized using a
standard sql url.