### PR TITLE
#162054352 Implement off-boarding email automation

### DIFF
--- a/server/jobs/offboarding/email.js
+++ b/server/jobs/offboarding/email.js
@@ -1,0 +1,29 @@
+
+/* eslint-disable no-param-reassign */
+import { itEmailTransport, opsOffBoardingEmailTransport } from '../../modules/email/emailModule';
+
+/**
+ * @desc Automates developer offboarding on slack
+ *
+ * @param {array} placement Placement record whose developer is to be offboarded
+ * @param {object} automationResult Result of automation job
+ * @returns {void}
+ */
+export default function emailOffboarding(placement, automationResult) {
+  const {
+    fellow: { name, email, location },
+    end_date: endDate,
+    client_name: partnerName,
+  } = placement;
+  return itEmailTransport(name, email, location, endDate)
+    .then(() => opsOffBoardingEmailTransport(name, partnerName, email, location, endDate)
+      .then(() => {
+        automationResult.emailAutomation = 'success';
+      })
+      .catch(() => {
+        automationResult.emailAutomation = 'failure';
+      }))
+    .catch(() => {
+      automationResult.emailAutomation = 'failure';
+    });
+}

--- a/server/modules/email/emailModule.js
+++ b/server/modules/email/emailModule.js
@@ -87,6 +87,16 @@ export const opsEmailTransport = (
   return sendMail(mailOptions);
 };
 
+/**
+ * @desc Sends an email to IT to wipe the machine of the developer
+ *
+ * @param {any} developerName Name of the roller off developer
+ * @param {any} developerEmail Email of the developer
+ * @param {any} developerLocation Location of the developer: Lagos || Nairobi || Kampala
+ * @param {any} rollOffDate Date the developer rolled off
+ *
+ * @returns {Promise} Promise which resolves to success message or error if email fails
+ */
 export const itEmailTransport = (developerName, developerEmail, developerLocation, rollOffDate) => {
   const mailOptions = {
     from: user,
@@ -95,7 +105,6 @@ export const itEmailTransport = (developerName, developerEmail, developerLocatio
     generateTextFromHTML: true,
     html: eval(`\`${fs.readFileSync(itOffboardingPath).toString()}\``),
   };
-
   return sendMail(mailOptions);
 };
 
@@ -106,7 +115,6 @@ export const itEmailTransport = (developerName, developerEmail, developerLocatio
  * @param {string} parnerName - Name of partner
  * @param {string} developerEmail - Email of the developer
  * @param {string} developerLocation - location of developer
- * @param {stirng} parnerLocation - location of partner
  * @param {string} rollOffDate - date for developer to roll off
  *
  * @returns {object}  Promise
@@ -117,7 +125,6 @@ export const opsOffBoardingEmailTransport = (...args) => {
     partnerName,
     developerEmail,
     developerLocation,
-    partnerLocation,
     rollOffDate,
   ] = args;
   const mailOptions = {


### PR DESCRIPTION
#### What does this PR do?
Add off-boarding email automation to the background worker

#### Description of Task to be completed?
- create email off-boarding module and define emailOffboarding function, to
- send email to IT to wipe developer's machine
- send email to Success-Ops with info of rolled off dev

#### How should this be manually tested?
1. Set environment variable: `TIMER_INTERVAL=15s`
2. Log `automationResult` object for each placement in `executeJobs` function
2. On terminal, run: `npm start` or `yarn start`
3. Watch the terminal to view the status of email offboarding jobs, printed every 15 seconds interval


#### Any background context you want to provide?
Make use of the following functions:
- `opsOffBoardingEmailTransport`
- `itEmailTransport`

#### What are the relevant pivotal tracker stories?
[#162054352](https://www.pivotaltracker.com/story/show/162054352)

#### Postman Documentation
N/A
