### PR TITLE
#162348281 Fix Partner Channel Naming

### DIFF
--- a/server/helpers/slackHelpers.js
+++ b/server/helpers/slackHelpers.js
@@ -10,12 +10,11 @@ const makeChannelNames = (partnerName) => {
   const formattedName = shortened.replace(/[^a-zA-Z0-9]/g, '');
 
   // For all the participants of the engagement - Andelans & Partners
-  const generalChannel = `p-${formattedName}`;
+  const generalChannel = `p-${formattedName.substring(0, 19)}`;
   // For only Andelans in the engagement
-  const internalChannel = `p-${formattedName}-int`;
+  const internalChannel = `p-${formattedName.substring(0, 15)}-int`;
 
   return { generalChannel, internalChannel };
 };
-
 
 export default makeChannelNames;


### PR DESCRIPTION
#### What does this PR do?
It ensures that even with a long partner name, both partner channels are created.

#### Description of Task to be completed?
Fix a bug to ensure that a partner channel is created even when the partner name is more than 22 characters.

#### How should this be manually tested?
- Clone and set up the project using the instruction in the README.
- $ git checkout to bg-fix-partner-channel-naming-162348281 branch which contains the changes.
- Run the createPartnerChannels function using the id of a long partner name.

#### Any background context you want to provide?
For a slack channel to be created, its name should have a maximum of 22 characters. Hence the shortening of long partner names.

#### What are the relevant pivotal tracker stories?
[#162348281](https://www.pivotaltracker.com/story/show/162348281)

#### Postman Documentation
N/A