### PR TITLE
#162192801 Handle Letter Casing Edge Case on Freckle During Creating a Project

### DIFF
--- a/server/modules/freckle/projects.js
+++ b/server/modules/freckle/projects.js
@@ -35,6 +35,7 @@ export const createProject = async (projectName) => {
   try {
     let [project] = await getProjectByName(projectName);
     if (project) {
+      project.existMessage = `${projectName} already exists as ${project.name}.`;
       return project;
     }
     await axios.post(`${freckleUrl}/projects?freckle_token=${freckleToken}`, {


### PR DESCRIPTION
#### What does this PR do?
It handles the letter casing edge case on Freckle During creating a project.

#### Description of Task to be completed?
Fix a bug to ensure that a user is notified when they create a project with an already existing name all same combination of characters. This is because Freckle project naming is not case sensitive. 

#### How should this be manually tested?
- Clone and set up the project using the instruction in the README.
- $ git checkout to `bg-162192801-handle-letter-casing-edge-case-on-freckle` branch which contains the changes.
- Run the createProject function using an already existing project or a similar combination characters but different casing styles.
- Print out the project data object. 

#### Any background context you want to provide?
Freckle project naming is not case sensitive.

#### What are the relevant pivotal tracker stories?
[#162192801](https://www.pivotaltracker.com/story/show/162192801)

#### Postman Documentation
N/A