### PR TITLE
#162664345 Add fellow to rack-city slack channel during onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,7 @@ FRECKLE_ADMIN_TOKEN=personal access token of a freckle admin account
 # Slack
 SLACK_TOKEN=authentication-token-for-the-slack-channel
 SLACK_AVAILABLE_DEVS_CHANNEL_ID=available-developers-slack-channel-ID
+SLACK_RACK_CITY_CHANNEL_ID=rack-city-slack-channel-ID
 
 # Background Worker(milliseconds)
 TIMER_INTERVAL=set intervals to execute worker eg: 10s, 20m, 24h, 1d.

--- a/server/jobs/onboarding/slack.js
+++ b/server/jobs/onboarding/slack.js
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 import { accessChannel, createPartnerChannel } from '../../modules/slack/slackIntegration';
 
 dotenv.config();
-const { SLACK_AVAILABLE_DEVS_CHANNEL_ID } = process.env;
+const { SLACK_AVAILABLE_DEVS_CHANNEL_ID, SLACK_RACK_CITY_CHANNEL_ID } = process.env;
 
 /**
  * @desc Automates developer onboarding on slack
@@ -17,6 +17,7 @@ const slackOnBoarding = async (placement) => {
   const { client_name: partnerName } = placement;
 
   accessChannel(fellow.email, SLACK_AVAILABLE_DEVS_CHANNEL_ID, 'kick');
+  accessChannel(fellow.email, SLACK_RACK_CITY_CHANNEL_ID, 'invite');
   createPartnerChannel(partnerName, 'internal');
   createPartnerChannel(partnerName, 'general').then((channel) => {
     if (channel.id) {

--- a/server/validator.js
+++ b/server/validator.js
@@ -11,6 +11,7 @@ const validateEnvironmentVars = () => {
     'ANDELA_ALLOCATIONS_API_TOKEN',
     'FRECKLE_ADMIN_TOKEN',
     'SLACK_AVAILABLE_DEVS_CHANNEL_ID',
+    'SLACK_RACK_CITY_CHANNEL_ID',
     'ANDELA_API_BASE_URL',
   ];
   const missingVariable = [];


### PR DESCRIPTION
#### What does this PR do?
- add SLACK_RACK_CITY_CHANNEL_ID as a required env var
- update the slack onboarding job
#### Description of Task to be completed?
Add fellow to rack city slack channel for onboarding placement.

#### How should this be manually tested?
- Add the ID of the `rack-city` slack channel to the to the environment variable as `SLACK_RACK_CITY_CHANNEL_ID`
- Start the app
- As soon as there is a new placement from allocations
- The fellow placed should be added to the `rack-city` slack channel as part of onboarding automation.

#### What are the relevant pivotal tracker stories?
#162664345