### PR TITLE
#162414292 Persist the result of email automation

### DIFF
--- a/db/migrations/20181210091511-createSlackAutomationTable.js
+++ b/db/migrations/20181210091511-createSlackAutomationTable.js
@@ -35,6 +35,7 @@ module.exports = {
     },
     automationId: {
       type: DataTypes.INTEGER,
+      allowNull: false,
       references: {
         model: 'automation',
         key: 'id',

--- a/db/migrations/20181210092417-createEmailAutomationTable.js
+++ b/db/migrations/20181210092417-createEmailAutomationTable.js
@@ -34,6 +34,7 @@ module.exports = {
     },
     automationId: {
       type: DataTypes.INTEGER,
+      allowNull: false,
       references: {
         model: 'automation',
         key: 'id',

--- a/db/migrations/20181210092705-createFreckleAutomationTable.js
+++ b/db/migrations/20181210092705-createFreckleAutomationTable.js
@@ -31,6 +31,7 @@ module.exports = {
     },
     automationId: {
       type: DataTypes.INTEGER,
+      allowNull: false,
       references: {
         model: 'automation',
         key: 'id',

--- a/db/operations/automations.js
+++ b/db/operations/automations.js
@@ -2,7 +2,7 @@ import sequelize from 'sequelize';
 import db from '../../server/models';
 
 const { Op } = sequelize;
-const { SlackAutomation, Automation } = db;
+const { SlackAutomation, EmailAutomation, Automation } = db;
 
 /**
  * @func createOrUpdateSlackAutomation
@@ -15,26 +15,14 @@ const { SlackAutomation, Automation } = db;
  * @param {string} automationDetails.type Automation type: create || kick || invite
  * @param {string} automationDetails.status Automation status: success || failure
  * @param {string} automationDetails.statusMessage Status message
- * @param {string} [automationDetails.slackAutomationId] ID of existing slackAutomation.
+ * @param {string} [automationDetails.id] ID of existing slackAutomation.
  * For updating purpose alone.
  *
  * @return {Promise} Promise that resolves the created/updated slackAutomation.
  */
-export const createOrUpdateSlackAutomation = (automationDetails) => {
-  const { slackAutomationId } = automationDetails;
-  if (slackAutomationId) {
-    return SlackAutomation.find({ where: { id: slackAutomationId } }).then((result) => {
-      result.update({
-        channelId: automationDetails.channelId || result.channelId,
-        channelName: automationDetails.channelName || result.channelName,
-        slackUserId: automationDetails.slackUserId || result.slackUserId,
-        status: automationDetails.status || result.status,
-        statusMessage: automationDetails.statusMessage || result.statusMessage,
-      });
-    });
-  }
-  return SlackAutomation.create(automationDetails);
-};
+export const createOrUpdateSlackAutomation = automationDetails => (
+  SlackAutomation.upsertById(automationDetails)
+);
 
 /**
  * @func getSlackAutomation
@@ -55,6 +43,27 @@ export const getSlackAutomation = (automationDetails) => {
     },
   });
 };
+
+/**
+ * @func createOrUpdateEmaillAutomation
+ * @desc create or update an emailAutomation in the Database.
+ *
+ * @param {object} automationDetails Details about the email automation to be created
+ * @param {string} automationDetails.automationId ID of the connected automation
+ * @param {string} automationDetails.body Body of the email
+ * @param {string} automationDetails.recipient Recipient of the email
+ * @param {string} automationDetails.sender Sender of the email
+ * @param {string} automationDetails.subject Subject of the email
+ * @param {string} automationDetails.status Automation status: success || failure
+ * @param {string} automationDetails.statusMessage Status message
+ * @param {string} [automationDetails.id] ID of existing emailAutomation.
+ * For updating purpose alone.
+ *
+ * @return {Promise} Promise that resolves the created/updated emailAutomation.
+ */
+export const createOrUpdateEmaillAutomation = automationDetails => (
+  EmailAutomation.upsertById(automationDetails)
+);
 
 /**
  * @func createAutomation

--- a/package-lock.json
+++ b/package-lock.json
@@ -2826,6 +2826,15 @@
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -4164,6 +4173,11 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
     "is-odd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
@@ -4976,6 +4990,11 @@
           }
         }
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
     },
     "moment": {
       "version": "2.22.2",
@@ -6915,6 +6934,16 @@
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.6.0"
+      }
+    },
+    "proxyquire": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
+      "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.0",
+        "resolve": "~1.8.1"
       }
     },
     "ps-tree": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "nodemailer": "^4.6.8",
     "pg": "^7.4.3",
     "pg-hstore": "^2.3.2",
+    "proxyquire": "^2.1.0",
     "redis": "^2.8.0",
     "sequelize": "^4.38.0",
     "sequelize-cli": "^4.0.0",

--- a/server/models/emailAutomation.js
+++ b/server/models/emailAutomation.js
@@ -39,6 +39,7 @@ export default (sequelize, DataTypes) => {
     EmailAutomation.belongsTo(models.Automation, {
       foreignKey: {
         name: 'automationId',
+        allowNull: false,
       },
     });
   };

--- a/server/models/freckleAutomation.js
+++ b/server/models/freckleAutomation.js
@@ -24,6 +24,7 @@ export default (sequelize, DataTypes) => {
     FreckleAutomation.belongsTo(models.Automation, {
       foreignKey: {
         name: 'automationId',
+        allowNull: false,
       },
     });
   };

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -41,6 +41,19 @@ const db = {
 Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {
     db[modelName].associate(db);
+    db[modelName].upsertById = (values) => {
+      if (values.id) {
+        return db[modelName]
+          .update(values, { where: { id: values.id }, returning: true })
+          .then((res) => {
+            if (res[0] !== 1) {
+              throw new Error('upsert should just update 1 row');
+            }
+            return [res[1][0], false];
+          });
+      }
+      return db[modelName].create(values).then(res => [res, true]);
+    };
   }
 });
 

--- a/server/models/slackAutomation.js
+++ b/server/models/slackAutomation.js
@@ -28,6 +28,7 @@ export default (sequelize, DataTypes) => {
     SlackAutomation.belongsTo(models.Automation, {
       foreignKey: {
         name: 'automationId',
+        allowNull: false,
       },
     });
   };

--- a/test/db/automation.test.js
+++ b/test/db/automation.test.js
@@ -1,0 +1,68 @@
+import sinon from 'sinon';
+import { Op } from 'sequelize';
+import { makeMockModels } from 'sequelize-test-helpers';
+import proxyquire from 'proxyquire';
+
+/* eslint-disable no-unused-expressions */
+
+const mockModels = {
+  SlackAutomation: {
+    create: sinon.stub(),
+    find: sinon.stub(),
+    upsertById: sinon.stub(),
+  },
+  EmailAutomation: {
+    upsertById: sinon.stub(),
+  },
+  Automation: {
+    create: sinon.stub(),
+  },
+};
+
+const fakeModels = makeMockModels(mockModels);
+
+const automations = proxyquire('../../db/operations/automations', {
+  '../../server/models': fakeModels,
+});
+
+describe('Automation Database Operations', () => {
+  it('should create an automation record in the DB', async () => {
+    const automationDetails = {
+      partnerId: '-UTF56K',
+      // ...other properties...
+    };
+    await automations.createAutomation(automationDetails);
+    expect(mockModels.Automation.create.calledWith(automationDetails)).to.be.true;
+  });
+  it('should upsert a slackAutomation record in the DB', async () => {
+    const automationDetails = {
+      channelId: '555',
+      // ...other properties...
+    };
+    await automations.createOrUpdateSlackAutomation(automationDetails);
+    expect(mockModels.SlackAutomation.upsertById.calledWith(automationDetails)).to.be.true;
+  });
+  it('should get a slackAutomation record from the DB', async () => {
+    const automationDetails = {
+      slackAutomationId: '99',
+      channelName: 'p-test',
+      // ...other properties...
+    };
+    await automations.getSlackAutomation(automationDetails);
+    expect(mockModels.SlackAutomation.find.calledWith({
+      where: {
+        [Op.or]: [
+          { id: automationDetails.slackAutomationId },
+          { channelName: automationDetails.channelName },
+        ],
+      },
+    })).to.be.true;
+  });
+  it('should upsert an emailAutomation record in the DB', async () => {
+    const automationDetails = {
+      body: 'An email to be sent to anybody',
+    };
+    await automations.createOrUpdateEmaillAutomation(automationDetails);
+    expect(mockModels.EmailAutomation.upsertById.calledWith(automationDetails)).to.be.true;
+  });
+});

--- a/test/models/emailAutomation.test.js
+++ b/test/models/emailAutomation.test.js
@@ -27,6 +27,7 @@ describe('server/models/emailAutomation', () => {
       expect(EmailAutomation.belongsTo).to.have.been.calledWith(automation, {
         foreignKey: {
           name: 'automationId',
+          allowNull: false,
         },
       });
     });

--- a/test/models/freckleAutomation.test.js
+++ b/test/models/freckleAutomation.test.js
@@ -27,6 +27,7 @@ describe('server/models/freckleAutomation', () => {
       expect(FlackAutomation.belongsTo).to.have.been.calledWith(automation, {
         foreignKey: {
           name: 'automationId',
+          allowNull: false,
         },
       });
     });

--- a/test/models/slackAutomation.test.js
+++ b/test/models/slackAutomation.test.js
@@ -27,6 +27,7 @@ describe('server/models/slackAutomation', () => {
       expect(SlackAutomation.belongsTo).to.have.been.calledWith(automation, {
         foreignKey: {
           name: 'automationId',
+          allowNull: false,
         },
       });
     });


### PR DESCRIPTION
#### What does this PR do?
- create/modify functions to help persist automation to DB
- update some database models
- add a method `upsertById` to the sequelize models
- save an email automation to the database as soon as it is completed(or there is an error)

#### Description of Task to be completed?
Persist the result of email automation

### Background Context
I was unable to use the regular sequelize `upsert` method to perform a create or update database operation becuase it executes validations even for fields that are not to be updated. I resolved this by adding a custom `upsertById` method.
More details about the reason/implementation of the `upsertById` method [here](https://github.com/sequelize/sequelize/issues/5711) 

### How should this be manually tested?
- Checkout to the branch containing the changes of this Pull Request(`ch-persist-email-automatn-result`)
- Run `npm run undo:all:migrations` on the CLI to undo any previous migrations
- Run `npm run migrations` on the CLI to migrate the updated models into the database.
- Run `start:dev` to start the app
- As soon as there is a new placement from allocatios, the automations would be executed and the result for emailAutomation would be persisted to the database(in `emailAutomaiton` table).

#### What are the relevant pivotal tracker stories?
#162414292