### PR TITLE
#162414292 Persist automation partner details to database

### DIFF
--- a/db/migrations/20180716094745-createPartnerTable.js
+++ b/db/migrations/20180716094745-createPartnerTable.js
@@ -9,11 +9,9 @@ module.exports = {
       },
       freckleProjectId: {
         type: DataTypes.STRING,
-        allowNull: false,
       },
       name: {
         type: DataTypes.STRING,
-        allowNull: false,
       },
       partnerId: {
         type: DataTypes.STRING,
@@ -21,7 +19,6 @@ module.exports = {
       },
       slackChannels: {
         type: DataTypes.JSON,
-        allowNull: false,
       },
       createdAt: {
         allowNull: false,

--- a/db/operations/automations.js
+++ b/db/operations/automations.js
@@ -79,3 +79,46 @@ export const createOrUpdateEmaillAutomation = automationDetails => (
  * @return {Promise} Promise that resolves the created automation.
  */
 export const createAutomation = automationDetails => Automation.create(automationDetails);
+
+
+/**
+ * @func saveFreckleAutomation
+ * @desc save created freckId to database after automation operation.
+ *
+ * @param {string} partnerId partner id on allocation
+ * @param {string} freckleProjectId created freckle id
+ *
+ * @return {void}
+ */
+export const saveFreckleAutomation = async (partnerId, freckleProjectId) => {
+  await db.Partner.upsert({
+    partnerId,
+    freckleProjectId,
+  });
+};
+
+/**
+ * @func saveSlackAutomation
+ * @desc save details of created partner slack channels to database after automation operation.
+ *
+ * @param {string} partnerId partner id on allocation
+ * @param {string} partnerName partner name
+ * @param {object} partnerDetailInternal partner internal slack channel
+ * @param {object} partnerDetailGeneral partner general slack channel
+ *
+ * @return {void}
+ */
+export const saveSlackAutomation = async (partnerId,
+  partnerName,
+  partnerDetailInternal,
+  partnerDetailGeneral,
+) => {
+  await db.Partner.upsert({
+    partnerId,
+    name: partnerName,
+    slackChannels: JSON.stringify({
+      partnerDetailInternal: partnerDetailInternal.id,
+      partnerDetailGeneral: partnerDetailGeneral.id,
+    }),
+  });
+};

--- a/db/operations/automations.js
+++ b/db/operations/automations.js
@@ -80,45 +80,25 @@ export const createOrUpdateEmaillAutomation = automationDetails => (
  */
 export const createAutomation = automationDetails => Automation.create(automationDetails);
 
-
 /**
- * @func saveFreckleAutomation
- * @desc save created freckId to database after automation operation.
+ * @func creatOrUpdatePartnerRecord
+ * @desc create or update a partner record in the database
  *
- * @param {string} partnerId partner id on allocation
- * @param {string} freckleProjectId created freckle id
+ * @param {object} partnerDetails The partner details
+ * @param {string} partnerDetails.name Name of partner
+ * @param {string} partnerDetails.partnerId Id of partner from allocaitons
+ * @param {string} partnerDetails.freckleProjectId The partner freckle project ID
+ * @param {string} partnerDetails.slackChannels The partner slack channels
+ * @param {string} partnerDetails.slackChannels.internal The partner internal slack channel
+ * @param {string} partnerDetails.slackChannels.general The partner general slack channel
  *
- * @return {void}
+ * @returns {Promise} Promise that resolves to the created/updated partner record
  */
-export const saveFreckleAutomation = async (partnerId, freckleProjectId) => {
-  await db.Partner.upsert({
-    partnerId,
-    freckleProjectId,
-  });
-};
-
-/**
- * @func saveSlackAutomation
- * @desc save details of created partner slack channels to database after automation operation.
- *
- * @param {string} partnerId partner id on allocation
- * @param {string} partnerName partner name
- * @param {object} partnerDetailInternal partner internal slack channel
- * @param {object} partnerDetailGeneral partner general slack channel
- *
- * @return {void}
- */
-export const saveSlackAutomation = async (partnerId,
-  partnerName,
-  partnerDetailInternal,
-  partnerDetailGeneral,
-) => {
-  await db.Partner.upsert({
-    partnerId,
-    name: partnerName,
-    slackChannels: JSON.stringify({
-      partnerDetailInternal: partnerDetailInternal.id,
-      partnerDetailGeneral: partnerDetailGeneral.id,
-    }),
-  });
+export const creatOrUpdatePartnerRecord = async (partnerDetails) => {
+  const { partnerId } = partnerDetails;
+  const existingRecord = await db.Partner.find({ where: { partnerId } });
+  if (existingRecord) {
+    return db.Partner.update(partnerDetails, { where: { partnerId } });
+  }
+  return db.Partner.create(partnerDetails);
 };

--- a/server/jobs/onboarding/freckle.js
+++ b/server/jobs/onboarding/freckle.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { getOrCreateProject, assignProject } from '../../modules/freckle/projects';
+import { saveFreckleAutomation } from '../../../db/operations/automations';
 
 /**
  * @desc Automates freckle developer onboarding.
@@ -9,8 +10,11 @@ import { getOrCreateProject, assignProject } from '../../modules/freckle/project
  * @returns {undefined}
  */
 export default async (placement) => {
-  const { fellow } = placement;
-  getOrCreateProject(placement.client_name).then((project) => {
-    if (project.id) assignProject(fellow.email, project.id);
+  const { fellow, id: partnerId } = placement;
+  getOrCreateProject(placement.client_name).then(async (project) => {
+    if (project.id) {
+      assignProject(fellow.email, project.id);
+      saveFreckleAutomation(partnerId, project.id);
+    }
   });
 };

--- a/server/jobs/onboarding/freckle.js
+++ b/server/jobs/onboarding/freckle.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { getOrCreateProject, assignProject } from '../../modules/freckle/projects';
-import { saveFreckleAutomation } from '../../../db/operations/automations';
+import { creatOrUpdatePartnerRecord } from '../../../db/operations/automations';
 
 /**
  * @desc Automates freckle developer onboarding.
@@ -10,11 +10,15 @@ import { saveFreckleAutomation } from '../../../db/operations/automations';
  * @returns {undefined}
  */
 export default async (placement) => {
-  const { fellow, id: partnerId } = placement;
-  getOrCreateProject(placement.client_name).then(async (project) => {
+  const { fellow, id: partnerId, client_name: partnerName } = placement;
+  getOrCreateProject(placement.client_name).then((project) => {
     if (project.id) {
       assignProject(fellow.email, project.id);
-      saveFreckleAutomation(partnerId, project.id);
+      creatOrUpdatePartnerRecord({
+        partnerId,
+        name: partnerName,
+        freckleProjectId: project.id,
+      });
     }
   });
 };

--- a/server/jobs/onboarding/slack.js
+++ b/server/jobs/onboarding/slack.js
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 import { accessChannel, createPartnerChannel } from '../../modules/slack/slackIntegration';
-import { saveSlackAutomation } from '../../../db/operations/automations';
+import { creatOrUpdatePartnerRecord } from '../../../db/operations/automations';
 
 dotenv.config();
 const { SLACK_AVAILABLE_DEVS_CHANNEL_ID, SLACK_RACK_CITY_CHANNEL_ID } = process.env;
@@ -18,14 +18,20 @@ const slackOnBoarding = async (placement) => {
   const { client_name: partnerName, id: partnerId } = placement;
 
   accessChannel(fellow.email, SLACK_AVAILABLE_DEVS_CHANNEL_ID, 'kick');
-  const partnerDetailInternal = await createPartnerChannel(partnerName, 'internal');
-  const partnerDetailGeneral = await createPartnerChannel(partnerName, 'general').then((channel) => {
-    if (channel.id) {
-      accessChannel(fellow.email, channel.id, 'invite');
-      saveSlackAutomation(partnerId, partnerName, partnerDetailInternal, partnerDetailGeneral);
-    }
-    return channel;
-  });
+  accessChannel(fellow.email, SLACK_RACK_CITY_CHANNEL_ID, 'invite');
+  const internalSlackChannel = await createPartnerChannel(partnerName, 'internal');
+  const generalSlackChannel = await createPartnerChannel(partnerName, 'general');
+  if (generalSlackChannel && generalSlackChannel.id) {
+    accessChannel(fellow.email, generalSlackChannel.id, 'invite');
+    creatOrUpdatePartnerRecord({
+      partnerId,
+      name: partnerName,
+      slackChannels: {
+        internal: internalSlackChannel.id,
+        general: generalSlackChannel.id,
+      },
+    });
+  }
 };
 
 export default slackOnBoarding;

--- a/server/modules/allocations.js
+++ b/server/modules/allocations.js
@@ -57,15 +57,6 @@ export async function findPartnerById(partnerId) {
 }
 
 /**
- *@desc Fetches placements from allocations, based on the status specified
- *
- * @param {string} status - The status of placements to fetch
- *
- * @returns {Promise} - Promise of the returned placements from allocations
- */
-const fetchPlacementsByStatus = status => axios.get(`api/v1/placements?status=${status}`);
-
-/**
  * @desc Fetches new placements based on status, from the past numberOfDays
  *
  * @param {string} status - The status of placements to fetch from allocations
@@ -74,9 +65,10 @@ const fetchPlacementsByStatus = status => axios.get(`api/v1/placements?status=${
  * @returns {Promise} - Promise which resolves to a list of placements
  * from the past numberOfDays provided, or throws an error if unsuccessful
  */
-export const fetchNewPlacements = (status, numberOfDays = 1) => fetchPlacementsByStatus(status).then((res) => {
-  const placements = res.data.values;
+export const fetchNewPlacements = async (status, numberOfDays = 1) => {
+  const response = await axios.get(`api/v1/placements?status=${status}`);
+  const placements = response.data.values;
   const currentDate = new Date(Date.now());
   const fromDate = currentDate.setDate(currentDate.getDate() - numberOfDays);
   return placements.filter(data => Date.parse(data.created_at) >= fromDate);
-});
+};


### PR DESCRIPTION
#### What does this PR do?
- add functionality to persist partner details after automation success
- refactor allocations.js for readability

#### Description of Task to be completed?
Persist the result of slack and freckle automation

#### How should this be manually tested?
1. Checkout to the branch containing the changes of this Pull Request(`ft-persist-partner-record`)
- Run `npm run undo:all:migrations` on the CLI to undo any previous migrations
- Run `npm run migrations` on the CLI to migrate the updated models into the database.
- Run `start:dev` to start the app
- As soon as there is a new placement from allocations, the automation would be executed and the result for slack and freckle automation would be persisted to the database(in `partners` table).



#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#162414292](https://www.pivotaltracker.com/story/show/162414292)

#### Postman Documentation
N/A

#### Screenshots (If applicable)
N/A