### PR TITLE
#162581856 Use partner slack channel ID during slack of-fboarding

### DIFF
--- a/db/operations/automations.js
+++ b/db/operations/automations.js
@@ -2,7 +2,9 @@ import sequelize from 'sequelize';
 import db from '../../server/models';
 
 const { Op } = sequelize;
-const { SlackAutomation, EmailAutomation, Automation } = db;
+const {
+  SlackAutomation, EmailAutomation, Automation, Partner,
+} = db;
 
 /**
  * @func createOrUpdateSlackAutomation
@@ -102,3 +104,12 @@ export const creatOrUpdatePartnerRecord = async (partnerDetails) => {
   }
   return db.Partner.create(partnerDetails);
 };
+
+/**
+ * @func getPartnerRecord
+ * @desc Get a partner record from the database
+ *
+ * @param {string} partnerId The id of the partner(from the placement data).
+ * @returns {Promise} Promise that resolves to the found partner record.
+ */
+export const getPartnerRecord = partnerId => Partner.find({ where: { partnerId } });

--- a/server/jobs/offboarding/slack.js
+++ b/server/jobs/offboarding/slack.js
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
 import { accessChannel } from '../../modules/slack/slackIntegration';
+import { getPartnerRecord } from '../../../db/operations/automations';
 /* eslint-disable no-param-reassign */
 
 dotenv.config();
@@ -13,7 +14,8 @@ const { SLACK_AVAILABLE_DEVS_CHANNEL_ID } = process.env;
  * @returns {undefined}
  */
 export default async function slackOffboarding(placement) {
-  const { fellow } = placement;
+  const { fellow, client_id: partnerId } = placement;
   accessChannel(fellow.email, SLACK_AVAILABLE_DEVS_CHANNEL_ID, 'invite');
-  accessChannel(fellow.email, 'partnerChannelId', 'kick');
+  const { slackChannels: { general } } = await getPartnerRecord(partnerId);
+  accessChannel(fellow.email, general, 'kick');
 }

--- a/server/jobs/onboarding/freckle.js
+++ b/server/jobs/onboarding/freckle.js
@@ -10,7 +10,7 @@ import { creatOrUpdatePartnerRecord } from '../../../db/operations/automations';
  * @returns {undefined}
  */
 export default async (placement) => {
-  const { fellow, id: partnerId, client_name: partnerName } = placement;
+  const { fellow, client_id: partnerId, client_name: partnerName } = placement;
   getOrCreateProject(placement.client_name).then((project) => {
     if (project.id) {
       assignProject(fellow.email, project.id);

--- a/server/jobs/onboarding/slack.js
+++ b/server/jobs/onboarding/slack.js
@@ -15,7 +15,7 @@ const { SLACK_AVAILABLE_DEVS_CHANNEL_ID, SLACK_RACK_CITY_CHANNEL_ID } = process.
  */
 const slackOnBoarding = async (placement) => {
   const { fellow } = placement;
-  const { client_name: partnerName, id: partnerId } = placement;
+  const { client_name: partnerName, client_id: partnerId } = placement;
 
   accessChannel(fellow.email, SLACK_AVAILABLE_DEVS_CHANNEL_ID, 'kick');
   accessChannel(fellow.email, SLACK_RACK_CITY_CHANNEL_ID, 'invite');

--- a/test/db/automation.test.js
+++ b/test/db/automation.test.js
@@ -17,6 +17,9 @@ const mockModels = {
   Automation: {
     create: sinon.stub(),
   },
+  Partner: {
+    find: sinon.stub(),
+  },
 };
 
 const fakeModels = makeMockModels(mockModels);
@@ -64,5 +67,10 @@ describe('Automation Database Operations', () => {
     };
     await automations.createOrUpdateEmaillAutomation(automationDetails);
     expect(mockModels.EmailAutomation.upsertById.calledWith(automationDetails)).to.be.true;
+  });
+  it('should get a partner record from the DB', async () => {
+    const partnerId = '-UTF56K';
+    await automations.getPartnerRecord(partnerId);
+    expect(mockModels.Partner.find.calledWith({ where: { partnerId } })).to.be.true;
   });
 });


### PR DESCRIPTION
#### What does this PR do?
- create a function to help fetch partner record from the DB
- use partner slack channel in slack offboarding job
- add tests for the created function

#### Description of Task to be completed?
Make use of actual partner channel during slack offboarding automation.

#### How should this be manually tested?
- Checkout to the branch containing the changes of this Pull Request(`bg-slack-offboarding-162581856`)
- Run `start:dev` to start the app
- As soon as there is a new offboarding placement from Allocations, the slack off-boarding job should be executed the rolled-off dev should no longer exist in the partner general channel.

#### What are the relevant pivotal tracker stories?
 #162581856
