### PR TITLE
#162951852 Fix import error when `npm start` command is run

### DIFF
--- a/server/jobs/index.js
+++ b/server/jobs/index.js
@@ -7,7 +7,7 @@ import fs from 'fs';
 import ms from 'ms';
 
 import { fetchNewPlacements } from '../modules/allocations';
-import { createAutomation } from '../../db/operations/automations';
+import { createAutomation } from '../modules/automations';
 import client from '../helpers/redis';
 
 /**

--- a/server/jobs/offboarding/slack.js
+++ b/server/jobs/offboarding/slack.js
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 import { accessChannel } from '../../modules/slack/slackIntegration';
-import { getPartnerRecord } from '../../../db/operations/automations';
+import { getPartnerRecord } from '../../modules/automations';
 /* eslint-disable no-param-reassign */
 
 dotenv.config();

--- a/server/jobs/onboarding/freckle.js
+++ b/server/jobs/onboarding/freckle.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { getOrCreateProject, assignProject } from '../../modules/freckle/projects';
-import { creatOrUpdatePartnerRecord } from '../../../db/operations/automations';
+import { creatOrUpdatePartnerRecord } from '../../modules/automations';
 
 /**
  * @desc Automates freckle developer onboarding.

--- a/server/jobs/onboarding/slack.js
+++ b/server/jobs/onboarding/slack.js
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 import { accessChannel, createPartnerChannel } from '../../modules/slack/slackIntegration';
-import { creatOrUpdatePartnerRecord } from '../../../db/operations/automations';
+import { creatOrUpdatePartnerRecord } from '../../modules/automations';
 
 dotenv.config();
 const { SLACK_AVAILABLE_DEVS_CHANNEL_ID, SLACK_RACK_CITY_CHANNEL_ID } = process.env;

--- a/server/modules/automations.js
+++ b/server/modules/automations.js
@@ -1,5 +1,5 @@
 import sequelize from 'sequelize';
-import db from '../../server/models';
+import db from '../models';
 
 const { Op } = sequelize;
 const {
@@ -22,9 +22,7 @@ const {
  *
  * @return {Promise} Promise that resolves the created/updated slackAutomation.
  */
-export const createOrUpdateSlackAutomation = automationDetails => (
-  SlackAutomation.upsertById(automationDetails)
-);
+export const createOrUpdateSlackAutomation = automationDetails => SlackAutomation.upsertById(automationDetails);
 
 /**
  * @func getSlackAutomation
@@ -63,9 +61,7 @@ export const getSlackAutomation = (automationDetails) => {
  *
  * @return {Promise} Promise that resolves the created/updated emailAutomation.
  */
-export const createOrUpdateEmaillAutomation = automationDetails => (
-  EmailAutomation.upsertById(automationDetails)
-);
+export const createOrUpdateEmaillAutomation = automationDetails => EmailAutomation.upsertById(automationDetails);
 
 /**
  * @func createOrUpdateFreckleAutomation

--- a/server/modules/email/emailModule.js
+++ b/server/modules/email/emailModule.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
 import emailTransport from './emailTransport';
-import { createOrUpdateEmaillAutomation } from '../../../db/operations/automations';
+import { createOrUpdateEmaillAutomation } from '../automations';
 
 dotenv.config();
 
@@ -67,7 +67,6 @@ const constructMailOptions = ({ emailBody, sendTo, emailSubject }) => ({
   generateTextFromHTML: true,
   html: emailBody,
 });
-
 
 /* eslint-disable no-eval */
 /* eslint-disable no-unused-vars */
@@ -138,8 +137,12 @@ export const sendITOffboardingMail = async (mailInfo) => {
  */
 export const sendSOPOnboardingMail = async (mailInfo) => {
   const {
-    developerName, developerEmail, developerLocation,
-    partnerName, partnerLocation, startDate,
+    developerName,
+    developerEmail,
+    developerLocation,
+    partnerName,
+    partnerLocation,
+    startDate,
   } = mailInfo;
 
   const mailOptions = constructMailOptions({
@@ -167,8 +170,12 @@ export const sendSOPOnboardingMail = async (mailInfo) => {
  */
 export const sendSOPOffboardingMail = async (mailInfo) => {
   const {
-    developerName, developerEmail, developerLocation,
-    partnerName, partnerLocation, rollOffDate,
+    developerName,
+    developerEmail,
+    developerLocation,
+    partnerName,
+    partnerLocation,
+    rollOffDate,
   } = mailInfo;
 
   const mailOptions = constructMailOptions({

--- a/server/modules/freckle/projects.js
+++ b/server/modules/freckle/projects.js
@@ -4,7 +4,7 @@ import dotenv from 'dotenv';
 import response from '../../helpers/response';
 
 // eslint-disable-next-line max-len
-import { createOrUpdateFreckleAutomation } from '../../../db/operations/automations';
+import { createOrUpdateFreckleAutomation } from '../automations';
 
 dotenv.config();
 const freckleUrl = 'https://api.letsfreckle.com/v2';
@@ -49,7 +49,10 @@ export const getOrCreateProject = async (projectName) => {
       saveFreckleProject(projectDetails, `${projectName} freckle project already exist`);
       return projectDetails;
     }
-    ({ data: projectDetails } = await axios.post(`${freckleUrl}/projects?freckle_token=${freckleToken}`, name));
+    ({ data: projectDetails } = await axios.post(
+      `${freckleUrl}/projects?freckle_token=${freckleToken}`,
+      name,
+    ));
     saveFreckleProject(projectDetails, `${projectName} freckle project created`);
     return projectDetails;
   } catch (error) {

--- a/server/modules/slack/slackIntegration.js
+++ b/server/modules/slack/slackIntegration.js
@@ -1,7 +1,7 @@
 import { WebClient } from '@slack/client';
 import dotenv from 'dotenv';
 import makeChannelNames from '../../helpers/slackHelpers';
-import { createOrUpdateSlackAutomation, getSlackAutomation } from '../../../db/operations/automations';
+import { createOrUpdateSlackAutomation, getSlackAutomation } from '../automations';
 
 dotenv.config();
 const { SLACK_TOKEN } = process.env;

--- a/test/modules/automation.test.js
+++ b/test/modules/automation.test.js
@@ -27,8 +27,8 @@ const mockModels = {
 
 const fakeModels = makeMockModels(mockModels);
 
-const automations = proxyquire('../../db/operations/automations', {
-  '../../server/models': fakeModels,
+const automations = proxyquire('../../server/modules/automations', {
+  '../models': fakeModels,
 });
 
 describe('Automation Database Operations', () => {
@@ -55,14 +55,16 @@ describe('Automation Database Operations', () => {
       // ...other properties...
     };
     await automations.getSlackAutomation(automationDetails);
-    expect(mockModels.SlackAutomation.find.calledWith({
-      where: {
-        [Op.or]: [
-          { id: automationDetails.slackAutomationId },
-          { channelName: automationDetails.channelName },
-        ],
-      },
-    })).to.be.true;
+    expect(
+      mockModels.SlackAutomation.find.calledWith({
+        where: {
+          [Op.or]: [
+            { id: automationDetails.slackAutomationId },
+            { channelName: automationDetails.channelName },
+          ],
+        },
+      }),
+    ).to.be.true;
   });
   it('should upsert an emailAutomation record in the DB', async () => {
     const automationDetails = {

--- a/test/modules/slackIntegration.spec.js
+++ b/test/modules/slackIntegration.spec.js
@@ -8,27 +8,20 @@ const createOrUpdateSlackAutomation = sinon.stub();
 const getSlackAutomation = sinon.stub();
 
 const slack = proxyquire('../../server/modules/slack/slackIntegration', {
-  '../../../db/operations/automations': {
-    createOrUpdateSlackAutomation, getSlackAutomation,
+  '../automations': {
+    createOrUpdateSlackAutomation,
+    getSlackAutomation,
   },
 });
 
 const fakeSlackClient = {
-  get: sinon
-    .stub(client, 'get')
-    .callsFake((value, cb) => cb.apply(this, [null, rawAllocations])),
+  get: sinon.stub(client, 'get').callsFake((value, cb) => cb.apply(this, [null, rawAllocations])),
   lookupByEmail: sinon
     .stub(slack.slackClient.users, 'lookupByEmail')
     .callsFake(() => slackMocks.slackUser),
-  invite: sinon
-    .stub(slack.slackClient.groups, 'invite')
-    .callsFake(() => slackMocks.inviteUser),
-  kick: sinon
-    .stub(slack.slackClient.groups, 'kick')
-    .callsFake(() => slackMocks.removeUser),
-  create: sinon
-    .stub(slack.slackClient.groups, 'create')
-    .callsFake(() => slackMocks.createGroups),
+  invite: sinon.stub(slack.slackClient.groups, 'invite').callsFake(() => slackMocks.inviteUser),
+  kick: sinon.stub(slack.slackClient.groups, 'kick').callsFake(() => slackMocks.removeUser),
+  create: sinon.stub(slack.slackClient.groups, 'create').callsFake(() => slackMocks.createGroups),
 };
 
 /* eslint-disable no-unused-expressions */


### PR DESCRIPTION
#### What does this PR do?
Fixes import error when `npm start` command is run on terminal

#### Description of Task to be completed?
- move automations.js from `db/operations` to `server/modules` directory
- change import links to `automations.js` module to reflect new location
- move `automation.test.js` from `test/db` to `test/modules`

#### How should this be manually tested?
1. On terminal, run command: `npm start` to confirm that the server bundles and starts without throwing an error
2. Run command `npm test`, to ensure all tests pass and nothing breaks

#### Any background context you want to provide?
When a develloper runs `npm start` in the root directory of the project, an error:
```
SyntaxError: Unexpected token import
```
gets thrown in the console due to reference to ES6 `import` statement inside `db/operations/automations.js` which, as a result of it not being within `server` folder, was not transpiled by babel during application build.

#### What are the relevant pivotal tracker stories?
[#162951852](https://www.pivotaltracker.com/story/show/162951852)

#### Postman Documentation
N/A
