### PR TITLE
#163518846 Save both slack channel id and slack channel name to the database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,22 +3,25 @@ NODE_ENV=development
 # Swagger documentation host
 DOC_HOST=documentation_home
 
+# Application Running Port
+PORT=application port
+
 # Development database
 DB_DEV_NAME=database name
 DB_USER_NAME=database user name
 DB_PASSWORD=database password
 DB_DIALECT=postgres
 DB_PORT=database port
-DB_HOST=database host #if using docker adjust to DB_HOST=database 
+DB_HOST=database host #if using docker adjust to DB_HOST=database
 
 # Test database
-DB_TEST_URL=url-to-test-database #if using docker adjust to DB_HOST=database 
+DB_TEST_URL=url-to-test-database #if using docker adjust to DB_HOST=database
 
 # Staging database
-DB_STAGING_URL=url-to-staging-database #if using docker adjust to DB_HOST=database 
+DB_STAGING_URL=url-to-staging-database #if using docker adjust to DB_HOST=database
 
 # Production database
-DB_PROD_URL=url-to-production-database #if using docker adjust to DB_HOST=database 
+DB_PROD_URL=url-to-production-database #if using docker adjust to DB_HOST=database
 
 # Gmail
 GMAIL_CLIENT_ID=GMAIL-CLIENT-ID-HERE

--- a/server/modules/slack/slackIntegration.js
+++ b/server/modules/slack/slackIntegration.js
@@ -104,9 +104,9 @@ export const getSlackUserId = async (email) => {
  */
 
 export const accessChannel = async (email, channelId, context) => {
+  const channelInfo = await slackClient.groups.info({ channel: channelId });
   try {
     const slackAction = slackClient.groups[context];
-    const channelInfo = await slackClient.groups.info({ channel: channelId });
     const userId = await getSlackUserId(email);
     await slackAction({ user: userId, channelId });
     await createOrUpdateSlackAutomation({
@@ -119,7 +119,6 @@ export const accessChannel = async (email, channelId, context) => {
       statusMessage: `${email} ${context === 'invite' ? 'invited to' : 'kicked from'} a channel`,
     });
   } catch (error) {
-    const channelInfo = await slackClient.groups.info({ channel: channelId });
     await createOrUpdateSlackAutomation({
       automationId: process.env.AUTOMATION_ID,
       slackUserId: null,

--- a/server/modules/slack/slackIntegration.js
+++ b/server/modules/slack/slackIntegration.js
@@ -108,11 +108,11 @@ export const accessChannel = async (email, channelId, context) => {
     const slackAction = slackClient.groups[context];
     const channelInfo = await slackClient.groups.info({ channel: channelId });
     const userId = await getSlackUserId(email);
-    await slackAction({ user: userId, channel });
+    await slackAction({ user: userId, channelId });
     await createOrUpdateSlackAutomation({
       automationId: process.env.AUTOMATION_ID,
       slackUserId: userId,
-      channelId: channelId,
+      channelId,
       channelName: channelInfo.group.name,
       type: context,
       status: 'success',
@@ -123,7 +123,7 @@ export const accessChannel = async (email, channelId, context) => {
     await createOrUpdateSlackAutomation({
       automationId: process.env.AUTOMATION_ID,
       slackUserId: null,
-      channelId: channelId,
+      channelId,
       channelName: channelInfo.group.name,
       type: context,
       status: 'failure',

--- a/test/mocks/automations.js
+++ b/test/mocks/automations.js
@@ -19,7 +19,7 @@ export const automationsMockData = [{
       emailTo: 'User.Unknown@example.com',
       subject: 'Onboarding',
       status: 'success',
-    }
+    },
   ],
   slackAutomations:
     [{

--- a/test/mocks/slack.js
+++ b/test/mocks/slack.js
@@ -116,6 +116,46 @@ const slackMocks = {
   removeUser: {
     ok: true,
   },
+  groupInfo: {
+    ok: true,
+    group:
+      {
+        id: 'GBRR4B5E3',
+        name: 'rack-city',
+        is_group: true,
+        created: 1531645759,
+        creator: 'UBNE1D2BV',
+        is_archived: false,
+        name_normalized: 'rack-city',
+        is_mpim: false,
+        is_open: true,
+        last_read: '1547826649.000000',
+        latest:
+          {
+            user: 'UE4910GEQ',
+            type: 'message',
+            subtype: 'group_join',
+            ts: '1547483152.000200',
+            text: '<@UE4910GEQ> has joined the group',
+            inviter: 'UBNE1D2BV'
+          },
+        unread_count: 0,
+        unread_count_display: 0,
+        members: ['UBNE1D2BV', 'UBQ31C11N', 'UE4910GEQ'],
+        topic: { value: '', creator: '', last_set: 0 },
+        purpose: { value: '', creator: '', last_set: 0 }
+      },
+    scopes:
+      ['identify',
+        'bot',
+        'commands',
+        'groups:read',
+        'users:read',
+        'users:read.email',
+        'chat:write:bot',
+        'groups:write'],
+    acceptedScopes: ['groups:read']
+  }
 };
 
 export default slackMocks;

--- a/test/modules/slackIntegration.spec.js
+++ b/test/modules/slackIntegration.spec.js
@@ -20,6 +20,7 @@ const fakeSlackClient = {
   invite: sinon.stub(slack.slackClient.groups, 'invite').callsFake(() => slackMocks.inviteUser),
   kick: sinon.stub(slack.slackClient.groups, 'kick').callsFake(() => slackMocks.removeUser),
   create: sinon.stub(slack.slackClient.groups, 'create').callsFake(() => slackMocks.createGroups),
+  groupInfo: sinon.stub(slack.slackClient.groups, 'info').callsFake(() => slackMocks.groupInfo),
 };
 
 /* eslint-disable no-unused-expressions */
@@ -63,6 +64,7 @@ describe('Slack Integration Test Suite', async () => {
     await slack.accessChannel(email, channel, 'invite');
     expect(createOrUpdateSlackAutomation.calledOnce).to.be.true;
     expect(fakeSlackClient.invite.calledOnce).to.be.true;
+    expect(fakeSlackClient.groupInfo.calledOnce).to.be.true;
   });
   it('Should remove developers from channels and save the automation to DB', async () => {
     const email = 'johndoe@mail.com';
@@ -70,5 +72,6 @@ describe('Slack Integration Test Suite', async () => {
     await slack.accessChannel(email, channel, 'kick');
     expect(createOrUpdateSlackAutomation.calledOnce).to.be.true;
     expect(fakeSlackClient.kick.calledOnce).to.be.true;
+    expect(fakeSlackClient.groupInfo.calledOnce).to.be.true;
   });
 });

--- a/test/modules/slackIntegration.spec.js
+++ b/test/modules/slackIntegration.spec.js
@@ -59,14 +59,14 @@ describe('Slack Integration Test Suite', async () => {
   });
   it('Should add developers to respective channels and save the automation to DB', async () => {
     const email = 'johndoe@mail.com';
-    const channel = 'GDL7RDC5V';
+    const channel = 'GBRR4B5E3';
     await slack.accessChannel(email, channel, 'invite');
     expect(createOrUpdateSlackAutomation.calledOnce).to.be.true;
     expect(fakeSlackClient.invite.calledOnce).to.be.true;
   });
   it('Should remove developers from channels and save the automation to DB', async () => {
     const email = 'johndoe@mail.com';
-    const channel = 'GDL7RDC5V';
+    const channel = 'GBRR4B5E3';
     await slack.accessChannel(email, channel, 'kick');
     expect(createOrUpdateSlackAutomation.calledOnce).to.be.true;
     expect(fakeSlackClient.kick.calledOnce).to.be.true;


### PR DESCRIPTION
#### What does this PR do?
Save both Slack Channel ID and Slack Channel Name to the database to return them in the automations payload

#### Description of Task to be completed?
Save to the database both the Slack Channel Name and ID

#### How should this be manually tested?
- Start the project
- Fetch the automations and confirm if both channelName and channelId are available under slackActivities

#### What are the relevant pivotal tracker stories?
[#163518846](https://www.pivotaltracker.com/story/show/163518846)
