### PR TITLE
#163562508 Save Email Automations to the Database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,8 @@ defaults: &defaults
 jobs:
   build:
     <<: *defaults
+    environment:
+        TIMER_INTERVAL: 15s
     steps:
       - checkout
       # Download and cache dependencies

--- a/test/endpoints/mockAndelapi.test.js
+++ b/test/endpoints/mockAndelapi.test.js
@@ -20,12 +20,17 @@ describe('Tests for mockAndelaApi endpoint\n', () => {
         const fakeUserList = sinon.stub(slackClient.users, 'list').callsFake(() => slackMocks.userList);
         const { values } = res.body;
         expect(res).to.have.status(200);
-        // expect(res.body)
-        //   .to.have.property('values')
-        //   .to.be.an('array');
-        // expect(values.length > 0).to.equal(true);
-        // expect(values.length < 6).to.equal(true);
-        // expect(userEmails.includes(values[0].fellow.email)).to.equal(true);
+        expect(res.body)
+          .to.have.property('values')
+          .to.be.an('array');
+        expect(values.length > 0).to.equal(true);
+        expect(values.length < 6).to.equal(true);
+        console.log('=============USEREMAILS=======================');
+        console.log(userEmails);
+        console.log('====================================');
+        console.log('==========VALUEs==========================');
+        console.log(values);
+        console.log('====================================');
         fakeUserList.restore();
         done();
       });

--- a/test/modules/automation.test.js
+++ b/test/modules/automation.test.js
@@ -62,10 +62,20 @@ describe('Automation Database Operations', () => {
   });
   it('should upsert an emailAutomation record in the DB', async () => {
     const automationDetails = {
-      body: 'An email to be sent to anybody',
+      automationId: '3',
+      body:
+        '<p><b>Developer Placement Notification</b></p>\n\n<p>\n  This is to notify you that mr smith, mr.smith@andela.com, Lagos,\n  has been placed with payoff,  .\n</p>\n\nTheir expected start date is not specified\n~~\nPlease do provide them with any support they need to ensure smooth transition to their Partner Engagement.\n\n\nRegards,\n\nSuccess',
+      recipient: 'esarecipient@gmail.com',
+      sender: 'esa@andela.com',
+      subject: 'smith mr Placed with payoff',
+      status: 'success',
+      statusMessage: 'Email sent succesfully',
     };
     await automations.createOrUpdateEmaillAutomation(automationDetails);
     expect(mockModels.EmailAutomation.upsertById.calledWith(automationDetails)).to.be.true;
+    expect(mockModels.EmailAutomation.upsertById.firstCall.args[0].statusMessage).to.equal(
+      'Email sent succesfully',
+    );
   });
   it('should upsert a freckleAutomation record in the DB', async () => {
     const automationDetails = {


### PR DESCRIPTION
#### What does this PR do?
- Fixes bug on saving automation emails to the database


#### Description of Task to be completed?
- Save email automations to the database

#### How should this be manually tested?
1.  Git clone the repository
2. Checkout to `bg-save-email-automations-163562508`
3. Install necessary dependencies
4. Ensure the `.env` file is updated with the required variables
5. Start the server `yarn start:dev' 
6. Create a new placement and access email automations using the endpoint `localhost:8000/api/v1/automations`
7. Check the `emailAutomation` table as well to see the saved email automations


#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[163562508](https://www.pivotaltracker.com/story/show/163562508)

#### Postman Documentation
N/A

#### Screenshots (If applicable)
<img width="1440" alt="screen shot 2019-02-11 at 12 46 08" src="https://user-images.githubusercontent.com/29487740/52555555-21493d80-2dfb-11e9-9d54-65b496bcaaab.png">
