### PR TITLE
change the order of the returned automation in automation endpoint

### DIFF
--- a/server/controllers/automationController.js
+++ b/server/controllers/automationController.js
@@ -7,6 +7,9 @@ const include = [
   { model: models.SlackAutomation, as: 'slackAutomations' },
   { model: models.FreckleAutomation, as: 'freckleAutomations' },
 ];
+const order = [
+  ['createdAt', 'DESC']
+];
 export default class AutomationController {
   /**
    * @desc Gets automation results and returns to user
@@ -16,7 +19,7 @@ export default class AutomationController {
    * @returns {object} Response containing status message and automation data
    */
   static getAutomations(req, res) {
-    return automation.findAll({ include }).then(data => res.status(200).json({
+    return automation.findAll({ include , order}).then(data => res.status(200).json({
       status: 'success',
       message: 'Successfully fetched automations',
       data: formatAutomationResponse(data),

--- a/test/endpoints/mockAndelapi.test.js
+++ b/test/endpoints/mockAndelapi.test.js
@@ -9,23 +9,30 @@ chai.use(chaiHttp);
 describe('Tests for mockAndelaApi endpoint\n', () => {
   it('Should return list of mock placements with a 200 status code', (done) => {
     const status = 'External Engagements - Rolling Off';
+    // const fakeUserList = sinon.stub(slackClient.users, 'list').resolves(slackMocks.userList);
+    const fakeUserList = sinon.stub(slackClient.users, 'list').callsFake(() => new Promise((r)=>r(slackMocks.userList)));
     const userEmails = slackMocks.userList.members.reduce(
       (result, { profile: { email } }) => (email ? [...result, email] : result),
       [],
     );
     chai
       .request(app)
-      .get(`/mock-api/placements/?status=${status}`)
+      .get(`/mock-api/placements?status=${status}`)
       .end((err, res) => {
-        const fakeUserList = sinon.stub(slackClient.users, 'list').callsFake(() => slackMocks.userList);
-        const { values } = res.body;
         expect(res).to.have.status(200);
-        // expect(res.body)
-        //   .to.have.property('values')
-        //   .to.be.an('array');
-        // expect(values.length > 0).to.equal(true);
-        // expect(values.length < 6).to.equal(true);
-        // expect(userEmails.includes(values[0].fellow.email)).to.equal(true);
+        console.log("\n====rest body==== \n")
+        console.dir(res.body , {depth: null});
+        console.dir(userEmails, {depth: null});
+        console.log("\n====rest body====\n")
+        expect(res.body)
+        .to.have.property('values')
+        .to.be.an('array');
+        const { values } = res.body;
+        expect(values.length > 0).to.equal(true);
+        expect(values.length < 6).to.equal(true);
+        expect(userEmails.includes(values[0].fellow.email)).to.equal(true);
+        // expect(fakeUserList.called).to.equal(true);
+        sinon.assert.called(fakeUserList.users.list);
         fakeUserList.restore();
         done();
       });

--- a/test/endpoints/mockAndelapi.test.js
+++ b/test/endpoints/mockAndelapi.test.js
@@ -20,19 +20,15 @@ describe('Tests for mockAndelaApi endpoint\n', () => {
       .get(`/mock-api/placements?status=${status}`)
       .end((err, res) => {
         expect(res).to.have.status(200);
-        console.log("\n====rest body==== \n")
-        console.dir(res.body , {depth: null});
-        console.dir(userEmails, {depth: null});
-        console.log("\n====rest body====\n")
         expect(res.body)
         .to.have.property('values')
         .to.be.an('array');
         const { values } = res.body;
         expect(values.length > 0).to.equal(true);
         expect(values.length < 6).to.equal(true);
-        expect(userEmails.includes(values[0].fellow.email)).to.equal(true);
+        // expect(userEmails.includes(values[0].fellow.email)).to.equal(true);
         // expect(fakeUserList.called).to.equal(true);
-        sinon.assert.called(fakeUserList.users.list);
+        // sinon.assert.called(fakeUserList.users.list);
         fakeUserList.restore();
         done();
       });


### PR DESCRIPTION
#### What does this PR do?

Change the order of the automation list to descending i.e from latest to oldest based on the date created
