### PR TITLE
only allow user's email for account not deleted

### DIFF
--- a/server/mockAndelaApi/index.js
+++ b/server/mockAndelaApi/index.js
@@ -18,7 +18,9 @@ async function generatePlacements(status) {
   const placements = [];
   const { members } = await list();
   const emails = members.reduce(
-    (result, { profile: { email } }) => (email ? [...result, email] : result),
+    (result, { deleted, profile: { email } }) => {
+      return ((email && !deleted) ? [...result, email] : result);
+    },
     [],
   );
   // max: 5, min: 1


### PR DESCRIPTION
#### What does this PR do?

Prevent mock placement API from including email of users from slack that are deactivated

#### Description of Task to be completed?




#### What are the relevant pivotal tracker stories?

#164927171