### PR TITLE
#165083767 Get slack channels and save with partner records during automations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,8 @@ FRECKLE_ADMIN_TOKEN=personal access token of a freckle admin account
 SLACK_TOKEN=authentication-token-for-the-slack-channel
 SLACK_AVAILABLE_DEVS_CHANNEL_ID=available-developers-slack-channel-ID
 SLACK_RACK_CITY_CHANNEL_ID=rack-city-slack-channel-ID
+SLACK_ADMIN=email-of-the-owner-of-the-slack-workspace
+
 
 # Background Worker(milliseconds)
 TIMER_INTERVAL=set intervals to execute worker eg: 10s, 20m, 24h, 1d.
@@ -64,3 +66,6 @@ ALLOCATION_PLACEMENTS=http://localhost:8000/mock-api/placements
 
 #Placement actual api (in production) - commented out
 #ALLOCATION_PLACEMENTS=https://api-prod.andela.com/api/v1/placements
+
+# REDIS scan range
+SCAN_RANGE=1000000000000000000

--- a/db/migrations/20190129094771-updateSlackAutomationType.js
+++ b/db/migrations/20190129094771-updateSlackAutomationType.js
@@ -1,0 +1,14 @@
+const replaceEnum = require('sequelize-replace-enum-postgres').default;
+
+const tableUpdates = (queryInterface, enumKey) => ({
+  queryInterface,
+  tableName: 'slackAutomation',
+  columnName: 'type',
+  newValues: enumKey ? ['create', 'kick', 'invite', enumKey] : ['create', 'kick', 'invite'],
+  enumName: 'enum_slackAutomation_type',
+});
+
+module.exports = {
+  up: queryInterface => replaceEnum(tableUpdates(queryInterface, 'retrieve')),
+  down: queryInterface => replaceEnum(tableUpdates(queryInterface)),
+};

--- a/db/migrations/20190506094751-makePartnerIdUnique.js
+++ b/db/migrations/20190506094751-makePartnerIdUnique.js
@@ -1,0 +1,9 @@
+module.exports = {
+  up: (queryInterface, DataTypes) => queryInterface.changeColumn('partners', 'partnerId', {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true,
+  }),
+
+  down: (queryInterface, DataTypes) => queryInterface.changeColumn('partners', 'partnerId', DataTypes.STRING),
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -775,31 +775,74 @@
       "dev": true
     },
     "@slack/client": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@slack/client/-/client-4.10.0.tgz",
-      "integrity": "sha512-NQNfSUhnx1rzFOIjH+oSbt+7M187GTJvXuRfVMm26yLKEMaYQGTVWrIXSlxnc+V4V9T7IqKMNFdk9qltATn0gw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/client/-/client-5.0.1.tgz",
+      "integrity": "sha512-rU3x3pVhKq+9gt2sDdQI6toYc9BmLCDU9UYpnGhlHWV+ebHXepftMLOuZqjt2inK9XLzz5XqJYKdsyfbCuwiJA==",
       "requires": {
+        "@slack/logger": "1.0.0",
+        "@slack/rtm-api": "5.0.1",
+        "@slack/types": "1.0.0",
+        "@slack/web-api": "5.0.1",
+        "@slack/webhook": "5.0.0"
+      }
+    },
+    "@slack/logger": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-1.0.0.tgz",
+      "integrity": "sha512-QDYhQR/58xKfB5iquvQwfpxPsmKPP/5SuDp8hRhZeUluCHsP1qBCOc3sW2Xb3cydxK0PAEnkLbBJf/ezsGwtlA==",
+      "requires": {
+        "@types/node": "11.10.4"
+      }
+    },
+    "@slack/rtm-api": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/rtm-api/-/rtm-api-5.0.1.tgz",
+      "integrity": "sha512-M8qcWssFg9SmNUSkxDE230ahl+toRJKRG76PluGL6EqlPcbLqzJYpwPBTPLq6WADYo6yNd6WGGQ4Qtzw/b7rvw==",
+      "requires": {
+        "@slack/logger": "1.0.0",
+        "@slack/web-api": "5.0.1",
+        "@types/node": "11.10.4",
+        "@types/p-queue": "2.3.2",
+        "@types/ws": "5.1.2",
+        "eventemitter3": "3.1.0",
+        "finity": "0.5.4",
+        "p-cancelable": "1.1.0",
+        "p-queue": "2.4.2",
+        "ws": "5.2.2"
+      }
+    },
+    "@slack/types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.0.0.tgz",
+      "integrity": "sha512-IktC4uD/CHfLQcSitKSmjmRu4a6+Nf/KzfS6dTgUlDzENhh26l8aESKAuIpvYD5VOOE6NxDDIAdPJOXBvUGxlg=="
+    },
+    "@slack/web-api": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.0.1.tgz",
+      "integrity": "sha512-L2Nc8P+NjXH1yqnsNhqxsrbpW3Qv+//9X5PQqcM3bctDmvmwTuhuM1X208RVD2avhnC89aghY5PssyaayWj5sA==",
+      "requires": {
+        "@slack/logger": "1.0.0",
+        "@slack/types": "1.0.0",
         "@types/form-data": "2.2.1",
         "@types/is-stream": "1.1.0",
         "@types/node": "11.10.4",
-        "@types/p-cancelable": "0.3.0",
         "@types/p-queue": "2.3.2",
-        "@types/p-retry": "1.0.1",
-        "@types/retry": "0.10.2",
-        "@types/ws": "5.1.2",
         "axios": "0.18.0",
         "eventemitter3": "3.1.0",
-        "finity": "0.5.4",
         "form-data": "2.3.3",
         "is-stream": "1.1.0",
-        "object.entries": "1.1.0",
-        "object.getownpropertydescriptors": "2.0.3",
-        "object.values": "1.1.0",
-        "p-cancelable": "0.3.0",
         "p-queue": "2.4.2",
-        "p-retry": "2.0.0",
-        "retry": "0.12.0",
-        "ws": "5.2.2"
+        "p-retry": "4.1.0"
+      }
+    },
+    "@slack/webhook": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-5.0.0.tgz",
+      "integrity": "sha512-cDj3kz3x9z9271xPNzlwb90DpKTYybG2OWPJHigJL8FegR80rzQyD0v4bGuStGGkHbAYDKE2BMpJambR55hnSg==",
+      "requires": {
+        "@slack/types": "1.0.0",
+        "@types/node": "11.10.4",
+        "axios": "0.18.0"
       }
     },
     "@types/chai": {
@@ -843,28 +886,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.4.tgz",
       "integrity": "sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg=="
     },
-    "@types/p-cancelable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@types/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha512-sP+9Ivnpil7cdmvr5O+145aXm65YX8Y+Lrul1ojdYz6yaE05Dqonn6Z9v5eqJCQ0UeSGcTRtepMlZDh9ywdKgw=="
-    },
     "@types/p-queue": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
       "integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
     },
-    "@types/p-retry": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/p-retry/-/p-retry-1.0.1.tgz",
-      "integrity": "sha512-HgQPG9kkUb4EpTeUv2taH2nBZsVUb5aOTSw3X2YozcTG1ttmGcLaLKx1MbAz1evVfUEDTCAPmdz2HiFztIyWrw==",
-      "requires": {
-        "@types/retry": "0.10.2"
-      }
-    },
     "@types/retry": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.10.2.tgz",
-      "integrity": "sha512-LqJkY4VQ7S09XhI7kA3ON71AxauROhSv74639VsNXC9ish4IWHnIi98if+nP1MxQV3RMPqXSCYgpPsDHjlg9UQ=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -1830,6 +1860,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "1.1.0"
       }
@@ -2081,6 +2112,7 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "1.2.0",
         "function-bind": "1.1.1",
@@ -2094,6 +2126,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
       "requires": {
         "is-callable": "1.1.4",
         "is-date-object": "1.0.1",
@@ -2867,21 +2900,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "optional": true,
           "requires": {
             "delegates": "1.0.0",
@@ -2890,11 +2927,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -2902,29 +2941,35 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -2932,22 +2977,26 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
             "minipass": "2.3.5"
@@ -2955,12 +3004,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
             "aproba": "1.2.0",
@@ -2975,7 +3026,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "optional": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -2988,12 +3040,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
             "safer-buffer": "2.1.2"
@@ -3001,7 +3055,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
             "minimatch": "3.0.4"
@@ -3009,7 +3064,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
             "once": "1.4.0",
@@ -3018,39 +3074,46 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "requires": {
             "safe-buffer": "5.1.2",
             "yallist": "3.0.3"
@@ -3058,7 +3121,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "optional": true,
           "requires": {
             "minipass": "2.3.5"
@@ -3066,19 +3130,22 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "optional": true
         },
         "needle": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+          "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "optional": true,
           "requires": {
             "debug": "2.6.9",
@@ -3088,7 +3155,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+          "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "optional": true,
           "requires": {
             "detect-libc": "1.0.3",
@@ -3105,7 +3173,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
             "abbrev": "1.1.1",
@@ -3114,12 +3183,14 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+          "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
+          "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
           "optional": true,
           "requires": {
             "ignore-walk": "3.0.1",
@@ -3128,7 +3199,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.5",
@@ -3139,33 +3211,39 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
@@ -3174,17 +3252,20 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "optional": true,
           "requires": {
             "deep-extend": "0.6.0",
@@ -3195,14 +3276,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -3216,7 +3299,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "optional": true,
           "requires": {
             "glob": "7.1.3"
@@ -3224,36 +3308,43 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -3262,7 +3353,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
             "safe-buffer": "5.1.2"
@@ -3270,19 +3362,22 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "optional": true,
           "requires": {
             "chownr": "1.1.1",
@@ -3296,12 +3391,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "optional": true,
           "requires": {
             "string-width": "1.0.2"
@@ -3309,18 +3406,21 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -3567,6 +3667,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "1.1.1"
       }
@@ -3608,7 +3709,8 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -3881,7 +3983,8 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
     },
     "is-ci": {
       "version": "1.2.1",
@@ -3913,7 +4016,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -4075,6 +4179,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "1.0.3"
       }
@@ -4100,6 +4205,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
       "requires": {
         "has-symbols": "1.0.0"
       }
@@ -5084,12 +5190,14 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "append-transform": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+          "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
           "dev": true,
           "requires": {
             "default-require-extensions": "2.0.0"
@@ -5097,17 +5205,20 @@
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "async": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "dev": true,
           "requires": {
             "lodash": "4.17.11"
@@ -5115,12 +5226,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
@@ -5129,7 +5242,8 @@
         },
         "caching-transform": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.1.tgz",
+          "integrity": "sha512-Y1KTLNwSPd4ljsDrFOtyXVmm7Gnk42yQitNq43AhE+cwUR/e4T+rmOHs1IPtzBg8066GBJfTOj1rQYFSWSsH2g==",
           "dev": true,
           "requires": {
             "hasha": "3.0.0",
@@ -5140,12 +5254,14 @@
         },
         "camelcase": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
           "dev": true
         },
         "cliui": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
             "string-width": "2.1.1",
@@ -5155,28 +5271,33 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "commander": {
           "version": "2.17.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
           "dev": true,
           "optional": true
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+          "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.2"
@@ -5184,7 +5305,8 @@
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
             "lru-cache": "4.1.5",
@@ -5193,7 +5315,8 @@
         },
         "debug": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "2.1.1"
@@ -5201,12 +5324,14 @@
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+          "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
           "dev": true,
           "requires": {
             "strip-bom": "3.0.0"
@@ -5214,7 +5339,8 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
             "once": "1.4.0"
@@ -5222,7 +5348,8 @@
         },
         "error-ex": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+          "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
           "dev": true,
           "requires": {
             "is-arrayish": "0.2.1"
@@ -5230,12 +5357,14 @@
         },
         "es6-error": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+          "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
           "dev": true
         },
         "execa": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
             "cross-spawn": "6.0.5",
@@ -5249,7 +5378,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "6.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
               "dev": true,
               "requires": {
                 "nice-try": "1.0.5",
@@ -5263,7 +5393,8 @@
         },
         "find-cache-dir": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+          "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
           "dev": true,
           "requires": {
             "commondir": "1.0.1",
@@ -5273,7 +5404,8 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
             "locate-path": "3.0.0"
@@ -5281,7 +5413,8 @@
         },
         "foreground-child": {
           "version": "1.5.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
             "cross-spawn": "4.0.2",
@@ -5290,17 +5423,20 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
             "pump": "3.0.0"
@@ -5308,7 +5444,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5321,12 +5458,14 @@
         },
         "graceful-fs": {
           "version": "4.1.15",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
           "dev": true
         },
         "handlebars": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+          "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
           "dev": true,
           "requires": {
             "async": "2.6.2",
@@ -5337,19 +5476,22 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
           }
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "hasha": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+          "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
           "dev": true,
           "requires": {
             "is-stream": "1.1.0"
@@ -5357,17 +5499,20 @@
         },
         "hosted-git-info": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+          "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -5376,42 +5521,50 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invert-kv": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "istanbul-lib-coverage": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+          "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
+          "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
           "dev": true,
           "requires": {
             "append-transform": "1.0.0"
@@ -5419,7 +5572,8 @@
         },
         "istanbul-lib-report": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
+          "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "2.0.3",
@@ -5429,7 +5583,8 @@
           "dependencies": {
             "supports-color": {
               "version": "6.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
               "dev": true,
               "requires": {
                 "has-flag": "3.0.0"
@@ -5439,7 +5594,8 @@
         },
         "istanbul-lib-source-maps": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
+          "integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
           "dev": true,
           "requires": {
             "debug": "4.1.1",
@@ -5451,14 +5607,16 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
           }
         },
         "istanbul-reports": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
+          "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
           "dev": true,
           "requires": {
             "handlebars": "4.1.0"
@@ -5466,12 +5624,14 @@
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
           "dev": true
         },
         "lcid": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
             "invert-kv": "2.0.0"
@@ -5479,7 +5639,8 @@
         },
         "load-json-file": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.15",
@@ -5490,7 +5651,8 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
             "p-locate": "3.0.0",
@@ -5499,17 +5661,20 @@
         },
         "lodash": {
           "version": "4.17.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
           "dev": true
         },
         "lodash.flattendeep": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+          "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -5518,7 +5683,8 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
             "pify": "3.0.0"
@@ -5526,7 +5692,8 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+          "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
           "dev": true,
           "requires": {
             "p-defer": "1.0.0"
@@ -5534,7 +5701,8 @@
         },
         "mem": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+          "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "0.1.3",
@@ -5544,7 +5712,8 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+          "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "dev": true,
           "requires": {
             "source-map": "0.6.1"
@@ -5552,19 +5721,22 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true
             }
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
@@ -5572,12 +5744,14 @@
         },
         "minimist": {
           "version": "0.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -5585,24 +5759,28 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             }
           }
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "2.7.1",
@@ -5613,7 +5791,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "2.0.1"
@@ -5621,12 +5800,14 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -5634,7 +5815,8 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
             "minimist": "0.0.10",
@@ -5643,12 +5825,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
             "execa": "1.0.0",
@@ -5658,22 +5842,26 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-is-promise": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+          "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
           "dev": true
         },
         "p-limit": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
           "dev": true,
           "requires": {
             "p-try": "2.0.0"
@@ -5681,7 +5869,8 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
             "p-limit": "2.1.0"
@@ -5689,12 +5878,14 @@
         },
         "p-try": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
           "dev": true
         },
         "package-hash": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+          "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.15",
@@ -5705,7 +5896,8 @@
         },
         "parse-json": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
             "error-ex": "1.3.2",
@@ -5714,27 +5906,32 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "dev": true
         },
         "path-type": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
             "pify": "3.0.0"
@@ -5742,12 +5939,14 @@
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "pkg-dir": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
             "find-up": "3.0.0"
@@ -5755,12 +5954,14 @@
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
             "end-of-stream": "1.4.1",
@@ -5769,7 +5970,8 @@
         },
         "read-pkg": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "dev": true,
           "requires": {
             "load-json-file": "4.0.0",
@@ -5779,7 +5981,8 @@
         },
         "read-pkg-up": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
           "dev": true,
           "requires": {
             "find-up": "3.0.0",
@@ -5788,7 +5991,8 @@
         },
         "release-zalgo": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+          "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
           "dev": true,
           "requires": {
             "es6-error": "4.1.1"
@@ -5796,17 +6000,20 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
           "dev": true,
           "requires": {
             "path-parse": "1.0.6"
@@ -5814,12 +6021,14 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
             "glob": "7.1.3"
@@ -5827,22 +6036,26 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "semver": {
           "version": "5.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "1.0.0"
@@ -5850,17 +6063,20 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
             "foreground-child": "1.5.6",
@@ -5873,7 +6089,8 @@
         },
         "spdx-correct": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+          "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
           "dev": true,
           "requires": {
             "spdx-expression-parse": "3.0.0",
@@ -5882,12 +6099,14 @@
         },
         "spdx-exceptions": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+          "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
             "spdx-exceptions": "2.2.0",
@@ -5896,12 +6115,14 @@
         },
         "spdx-license-ids": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+          "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -5910,7 +6131,8 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
@@ -5918,17 +6140,20 @@
         },
         "strip-bom": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "test-exclude": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
+          "integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
@@ -5939,7 +6164,8 @@
         },
         "uglify-js": {
           "version": "3.4.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5949,7 +6175,8 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
               "dev": true,
               "optional": true
             }
@@ -5957,12 +6184,14 @@
         },
         "uuid": {
           "version": "3.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "dev": true,
           "requires": {
             "spdx-correct": "3.1.0",
@@ -5971,7 +6200,8 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -5979,17 +6209,20 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "1.0.2",
@@ -5998,12 +6231,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
@@ -6011,7 +6246,8 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -6021,7 +6257,8 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -6031,12 +6268,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+          "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.15",
@@ -6046,17 +6285,20 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "12.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
           "dev": true,
           "requires": {
             "cliui": "4.1.0",
@@ -6075,7 +6317,8 @@
         },
         "yargs-parser": {
           "version": "11.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
           "dev": true,
           "requires": {
             "camelcase": "5.0.0",
@@ -6126,7 +6369,8 @@
     "object-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -6152,20 +6396,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
       "requires": {
         "define-properties": "1.1.3",
         "es-abstract": "1.13.0",
         "function-bind": "1.1.1",
         "has": "1.0.3"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
-      "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0"
       }
     },
     "object.omit": {
@@ -6184,17 +6420,6 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "3.0.1"
-      }
-    },
-    "object.values": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-      "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.13.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3"
       }
     },
     "on-finished": {
@@ -6281,9 +6506,9 @@
       }
     },
     "p-cancelable": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -6312,10 +6537,11 @@
       "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
     },
     "p-retry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-2.0.0.tgz",
-      "integrity": "sha512-ZbCuzAmiwJ45q4evp/IG9D+5MUllGSUeCWwPt3j/tdYSi1KPkSD+46uqmAA1LhccDhOXv8kYZKNb8x78VflzfA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.1.0.tgz",
+      "integrity": "sha512-oepllyG9gX1qH4Sm20YAKxg1GA7L7puhvGnTfimi31P07zSIj7SDV6YtuAx9nbJF51DES+2CIIRkXs8GKqWJxA==",
       "requires": {
+        "@types/retry": "0.12.0",
         "retry": "0.12.0"
       }
     },
@@ -7188,6 +7414,11 @@
         "umzug": "2.2.0",
         "yargs": "8.0.2"
       }
+    },
+    "sequelize-replace-enum-postgres": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sequelize-replace-enum-postgres/-/sequelize-replace-enum-postgres-1.5.0.tgz",
+      "integrity": "sha512-Vn9mtBuNeuswqYWW/BTpyg7rHW5NlbFWSWgev+F+ihi5TFpDUGAB4Tj4/7E2D7kLrW/0ZP30f0VQmIhyMarU/Q=="
     },
     "sequelize-test-helpers": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "NODE_ENV=test nyc --reporter=lcov --reporter=html --reporter=text mocha --recursive test/* --compilers js:@babel/register --require @babel/polyfill --timeout 10000 --exit",
     "lint": "eslint .",
     "migrations": "sequelize db:migrate",
-    "undo:all:migrations": "sequelize db:migrate:undo:all"
+    "undo:all:migrations": "sequelize db:migrate:undo:all",
+    "reset": "dropdb bp-esa && createdb bp-esa && yarn migrations"
   },
   "repository": {
     "type": "git",
@@ -32,7 +33,7 @@
     "@babel/polyfill": "^7.2.5",
     "@babel/preset-env": "^7.2.3",
     "@babel/register": "^7.0.0",
-    "@slack/client": "^4.8.0",
+    "@slack/client": "^5.0.0",
     "axios": "^0.18.0",
     "body-parser": "^1.18.3",
     "chai-http": "^4.2.1",
@@ -53,7 +54,8 @@
     "sequelize": "^4.38.0",
     "sequelize-cli": "^4.0.0",
     "socket.io": "^2.2.0",
-    "jsonwebtoken": "^8.5.1"
+    "jsonwebtoken": "^8.5.1",
+    "sequelize-replace-enum-postgres": "^1.5.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "start:dev": "NODE_ENV=development nodemon ./server/index --exec babel-node --watch ./server",
     "start:debug": "NODE_ENV=development nodemon ./server/index --exec babel-node  --inspect-brk=0.0.0.0:9229 --watch ./server",
     "build": "babel ./server -d ./build",
-    "pretest": "NODE_ENV=test npm run undo:all:migrations && NODE_ENV=test npm run migrations",
-    "test": "NODE_ENV=test nyc --reporter=lcov --reporter=html --reporter=text mocha --recursive test/* --compilers js:@babel/register --require @babel/polyfill --timeout 10000 --exit",
+    "pretest": "NODE_ENV=test npm run reset-database && NODE_ENV=test npm run migrations",
+    "test": "NODE_ENV=test nyc --reporter=lcov --reporter=html --reporter=text mocha --recursive test/* --compilers js:@babel/register --require @babel/polyfill --timeout 150000 --exit",
     "lint": "eslint .",
     "migrations": "sequelize db:migrate",
-    "undo:all:migrations": "sequelize db:migrate:undo:all"
+    "reset-database": "sequelize db:drop && sequelize db:create"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "NODE_ENV=test nyc --reporter=lcov --reporter=html --reporter=text mocha --recursive test/* --compilers js:@babel/register --require @babel/polyfill --timeout 150000 --exit",
     "lint": "eslint .",
     "migrations": "sequelize db:migrate",
-    "reset-database": "sequelize db:drop && sequelize db:create",
+    "reset-database": "npx redis-cli FLUSHALL && sequelize db:drop && sequelize db:create",
     "undo:all:migrations": "sequelize db:migrate:undo:all",
     "docs": "./node_modules/.bin/jsdoc -c jsdoc.json"
   },

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "test": "NODE_ENV=test nyc --reporter=lcov --reporter=html --reporter=text mocha --recursive test/* --compilers js:@babel/register --require @babel/polyfill --timeout 10000 --exit",
     "lint": "eslint .",
     "migrations": "sequelize db:migrate",
-    "undo:all:migrations": "sequelize db:migrate:undo:all",
-    "reset": "dropdb bp-esa && createdb bp-esa && yarn migrations"
+    "undo:all:migrations": "sequelize db:migrate:undo:all"
   },
   "repository": {
     "type": "git",
@@ -43,6 +42,7 @@
     "googleapis": "^33.0.0",
     "http": "0.0.0",
     "http-proxy": "^1.17.0",
+    "jsonwebtoken": "^8.5.1",
     "moment": "^2.24.0",
     "morgan": "^1.9.1",
     "ms": "^2.1.1",
@@ -53,9 +53,8 @@
     "redis": "^2.8.0",
     "sequelize": "^4.38.0",
     "sequelize-cli": "^4.0.0",
-    "socket.io": "^2.2.0",
-    "jsonwebtoken": "^8.5.1",
-    "sequelize-replace-enum-postgres": "^1.5.0"
+    "sequelize-replace-enum-postgres": "^1.5.0",
+    "socket.io": "^2.2.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -6,12 +6,11 @@ const app = express();
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-
 /**
- * Decodes a token
- * @param {string} token provided by user
- * @returns {object} decoded token
-*/
+ * @desc Decodes a token
+ * @param {String} token provided by user
+ * @returns {Promise} Promise to return the decoded token
+ */
 async function decodeToken(token) {
   try {
     const decode = await jwt.decode(token);
@@ -21,27 +20,25 @@ async function decodeToken(token) {
   }
 }
 
-
 /**
- * Does Auth
- *  @param {object} req provided by user
- *  @param {object} res provided by user
- *  @returns {object} decoded token
-*/
+ * @desc Perform authentication
+ *  @param {Object} req provided by user
+ *  @param {Object} res provided by user
+ *  @returns {Promise} Promise to return json response containing decoded token
+ */
 async function authResponse(req, res) {
   const { token } = req.body;
   const decode = await decodeToken(token);
   if (decode) {
-    res.status(200).json({
+    return res.status(200).json({
       confirmation: 'success',
       decode,
     });
-  } else {
-    res.status(401).json({
-      confirmation: 'fail',
-      message: 'Invalid Token',
-    });
   }
+  return res.status(401).json({
+    confirmation: 'fail',
+    message: 'Invalid Token',
+  });
 }
 
 export default authResponse;

--- a/server/helpers/redis.js
+++ b/server/helpers/redis.js
@@ -1,4 +1,5 @@
 import redis from 'redis';
+import { promisify } from 'util';
 
 // redis setup
 const client = redis.createClient(process.env.REDIS_PORT, process.env.REDIS_HOST);
@@ -9,5 +10,10 @@ client.on('connect', () => {
 client.on('error', (err) => {
   console.log(`Something went wrong ${err}`);
 });
+export const redisdb = {
+  set: promisify(client.set).bind(client),
+  get: promisify(client.get).bind(client),
+  scan: promisify(client.scan).bind(client),
+};
 
 export default client;

--- a/server/helpers/redis.js
+++ b/server/helpers/redis.js
@@ -14,6 +14,7 @@ export const redisdb = {
   set: promisify(client.set).bind(client),
   get: promisify(client.get).bind(client),
   scan: promisify(client.scan).bind(client),
+  delete: promisify(client.del).bind(client),
 };
 
 export default client;

--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ worker.init();
 http.listen(port, () => {
   console.log(`App listening on port ${app.get('port')}`);
   console.log(`Timer Interval is set to ${process.env.TIMER_INTERVAL}`);
-  worker.exec();
+  setInterval(() => worker.exec(), ms(process.env.TIMER_INTERVAL || '1d'));
 });
 
 export default app;

--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ worker.init();
 http.listen(port, () => {
   console.log(`App listening on port ${app.get('port')}`);
   console.log(`Timer Interval is set to ${process.env.TIMER_INTERVAL}`);
-  setInterval(() => worker.exec(), ms(process.env.TIMER_INTERVAL || '1d'));
+  worker.exec();
 });
 
 export default app;

--- a/server/jobs/helpers.js
+++ b/server/jobs/helpers.js
@@ -1,5 +1,5 @@
 import { findPartnerById } from '../modules/allocations';
-import { createOrUpdateEmaillAutomation } from '../modules/automations';
+import { createOrUpdateEmailAutomation } from '../modules/automations';
 import { sendPlacementFetchAlertEmail } from '../modules/email/emailModule';
 
 export const count = { FAILED_COUNT_NUMBER: 0 };
@@ -54,5 +54,7 @@ export const checkFailureCount = async (failCount) => {
 export async function executeEmailAutomation(emailFunctions, placement, automationId) {
   const mailInfo = await getMailInfo(placement);
   const emailAutomations = await Promise.all(emailFunctions.map(func => func(mailInfo)));
-  emailAutomations.map(automationData => createOrUpdateEmaillAutomation({ ...automationData, automationId }));
+  await Promise.all(
+    emailAutomations.map(automationData => createOrUpdateEmailAutomation({ ...automationData, automationId })),
+  );
 }

--- a/server/jobs/helpers.js
+++ b/server/jobs/helpers.js
@@ -7,7 +7,7 @@ export const count = { FAILED_COUNT_NUMBER: 0 };
 /**
  * @desc Retrieves necessary info. to be sent via email for any given placement
  * @param {object} placement A placement instance from allocation
- * @returns {object} Mail info to be sent
+ * @returns {Promise} Promise to return info of the mail to be sent
  */
 export const getMailInfo = async (placement) => {
   const {
@@ -32,7 +32,7 @@ export const getMailInfo = async (placement) => {
 /**
  * @desc Checks fail count then calls method to send failure email
  * @param {string} failCount Info about the number of times fetching placements has failed
- * @returns {Object} message about email being sent
+ * @returns {Promise} Promise to return an email sent message object
  */
 export const checkFailureCount = async (failCount) => {
   if (failCount >= parseInt(process.env.FETCH_FAIL_AUTOMATION_COUNT, 10)) {

--- a/server/jobs/offboarding/email.js
+++ b/server/jobs/offboarding/email.js
@@ -10,5 +10,9 @@ import { executeEmailAutomation } from '../helpers';
  * @returns {void}
  */
 export default function emailOffboarding(placement, automationId) {
-  executeEmailAutomation([sendSOPOffboardingMail, sendITOffboardingMail], placement, automationId);
+  return executeEmailAutomation(
+    [sendSOPOffboardingMail, sendITOffboardingMail],
+    placement,
+    automationId,
+  );
 }

--- a/server/jobs/offboarding/email.js
+++ b/server/jobs/offboarding/email.js
@@ -5,9 +5,9 @@ import { executeEmailAutomation } from '../helpers';
 /**
  * @desc Automates developer offboarding via email
  *
- * @param {object} placement Placement record whose developer is to be offboarded
- * @param {object} automationId ID of the particular automation
- * @returns {void}
+ * @param {Object} placement Placement record whose developer is to be offboarded
+ * @param {Object} automationId ID of the particular automation
+ * @returns {Promise} Promise to return the result of the email automation executed
  */
 export default function emailOffboarding(placement, automationId) {
   return executeEmailAutomation(

--- a/server/jobs/offboarding/slack.js
+++ b/server/jobs/offboarding/slack.js
@@ -10,20 +10,16 @@ const { SLACK_AVAILABLE_DEVS_CHANNEL_ID } = process.env;
 /**
  * @desc Automates developer offboarding on slack
  *
- * @param {object} placement Placement record whose developer is to be offboarded
- * @param {object} automationId ID of the automation being carried out
- * @returns {undefined}
+ * @param {Object} placement Placement record whose developer is to be offboarded
+ * @param {Object} automationId ID of the automation being carried out
+ * @returns {Promise} Promise to return the created/updated slack automation
  */
 export default async function slackOffboarding(placement, automationId) {
   const { fellow, client_id: partnerId } = placement;
   accessChannel(fellow.email, SLACK_AVAILABLE_DEVS_CHANNEL_ID, 'invite').then(response => createOrUpdateSlackAutomation({ ...response, automationId }));
   try {
-    const partnerRecord = await findPartnerById(partnerId, 'offboarding');
-    const response = await accessChannel(
-      fellow.email,
-      partnerRecord && partnerRecord.slackChannels.general,
-      'kick',
-    );
+    const { slackChannels } = await findPartnerById(partnerId, 'offboarding');
+    const response = await accessChannel(fellow.email, slackChannels.general, 'kick');
     return createOrUpdateSlackAutomation({ ...response, automationId });
   } catch (error) {
     return createOrUpdateSlackAutomation({

--- a/server/jobs/offboarding/slack.js
+++ b/server/jobs/offboarding/slack.js
@@ -1,7 +1,8 @@
+/* eslint-disable no-param-reassign */
 import dotenv from 'dotenv';
 import { accessChannel } from '../../modules/slack/slackIntegration';
-import { getPartnerRecord, createOrUpdateSlackAutomation } from '../../modules/automations';
-/* eslint-disable no-param-reassign */
+import { createOrUpdateSlackAutomation } from '../../modules/automations';
+import { findPartnerById } from '../../modules/allocations';
 
 dotenv.config();
 const { SLACK_AVAILABLE_DEVS_CHANNEL_ID } = process.env;
@@ -16,12 +17,20 @@ const { SLACK_AVAILABLE_DEVS_CHANNEL_ID } = process.env;
 export default async function slackOffboarding(placement, automationId) {
   const { fellow, client_id: partnerId } = placement;
   accessChannel(fellow.email, SLACK_AVAILABLE_DEVS_CHANNEL_ID, 'invite').then(response => createOrUpdateSlackAutomation({ ...response, automationId }));
-  getPartnerRecord(partnerId).then(async (partnerRecord) => {
+  try {
+    const partnerRecord = await findPartnerById(partnerId, 'offboarding');
     const response = await accessChannel(
       fellow.email,
-      partnerRecord && partnerRecord.channelId,
+      partnerRecord && partnerRecord.slackChannels.general,
       'kick',
     );
     return createOrUpdateSlackAutomation({ ...response, automationId });
-  });
+  } catch (error) {
+    return createOrUpdateSlackAutomation({
+      automationId,
+      status: 'failure',
+      statusMessage: error.message,
+      type: 'kick',
+    });
+  }
 }

--- a/server/jobs/onboarding/email.js
+++ b/server/jobs/onboarding/email.js
@@ -9,8 +9,6 @@ import { executeEmailAutomation } from '../helpers';
  * @param {object} automationId ID of the particular automation
  * @returns {void}
  */
-const emailOnboarding = async (placement, automationId) => {
-  executeEmailAutomation([sendDevOnboardingMail, sendSOPOnboardingMail], placement, automationId);
-};
+const emailOnboarding = async (placement, automationId) => executeEmailAutomation([sendDevOnboardingMail, sendSOPOnboardingMail], placement, automationId);
 
 export default emailOnboarding;

--- a/server/jobs/onboarding/email.js
+++ b/server/jobs/onboarding/email.js
@@ -5,9 +5,9 @@ import { executeEmailAutomation } from '../helpers';
 /**
  * @desc Automates developer onboarding on email
  *
- * @param {object} placement Placement record whose developer is to be offboarded
- * @param {object} automationId ID of the particular automation
- * @returns {void}
+ * @param {Object} placement Placement record whose developer is to be offboarded
+ * @param {Object} automationId ID of the particular automation
+ * @returns {Promise} Promise to return the result of emailAutomation performed
  */
 const emailOnboarding = async (placement, automationId) => executeEmailAutomation([sendDevOnboardingMail, sendSOPOnboardingMail], placement, automationId);
 

--- a/server/jobs/onboarding/freckle.js
+++ b/server/jobs/onboarding/freckle.js
@@ -6,16 +6,16 @@ import { createOrUpdateFreckleAutomation } from '../../modules/automations';
 /**
  * @desc Automates freckle developer onboarding.
  *
- * @param {object} placement Placement record whose developer is to be onboarded
- * @param {object} automationId Result of automation job
- * @returns {undefined}
+ * @param {Object} placement Placement record whose developer is to be onboarded
+ * @param {Object} automationId Result of automation job
+ * @returns {Promise} Promise to return the result of partner upserted after automation
  */
 const freckleOnboarding = async (placement, automationId) => {
   const { fellow, client_id: partnerId, client_name: partnerName } = placement;
   getOrCreateProject(placement.client_name).then(async (project) => {
     createOrUpdateFreckleAutomation({ ...project, automationId });
     assignProject(fellow.email, project.id).then(result => createOrUpdateFreckleAutomation({ ...result, automationId }));
-    db.Partner.upsert({
+    return db.Partner.upsert({
       partnerId,
       name: partnerName,
       freckleProjectId: project.id,

--- a/server/jobs/onboarding/freckle.js
+++ b/server/jobs/onboarding/freckle.js
@@ -1,9 +1,7 @@
 /* eslint-disable no-param-reassign */
+import db from '../../models';
 import { getOrCreateProject, assignProject } from '../../modules/freckle/projects';
-import {
-  creatOrUpdatePartnerRecord,
-  createOrUpdateFreckleAutomation,
-} from '../../modules/automations';
+import { createOrUpdateFreckleAutomation } from '../../modules/automations';
 
 /**
  * @desc Automates freckle developer onboarding.
@@ -17,7 +15,7 @@ const freckleOnboarding = async (placement, automationId) => {
   getOrCreateProject(placement.client_name).then(async (project) => {
     createOrUpdateFreckleAutomation({ ...project, automationId });
     assignProject(fellow.email, project.id).then(result => createOrUpdateFreckleAutomation({ ...result, automationId }));
-    creatOrUpdatePartnerRecord({
+    db.Partner.upsert({
       partnerId,
       name: partnerName,
       freckleProjectId: project.id,

--- a/server/jobs/onboarding/slack.js
+++ b/server/jobs/onboarding/slack.js
@@ -1,9 +1,7 @@
 import dotenv from 'dotenv';
+import db from '../../models';
 import { accessChannel, findOrCreatePartnerChannel } from '../../modules/slack/slackIntegration';
-import {
-  creatOrUpdatePartnerRecord,
-  createOrUpdateSlackAutomation,
-} from '../../modules/automations';
+import { createOrUpdateSlackAutomation } from '../../modules/automations';
 
 dotenv.config();
 const { SLACK_AVAILABLE_DEVS_CHANNEL_ID, SLACK_RACK_CITY_CHANNEL_ID } = process.env;
@@ -36,7 +34,7 @@ const slackOnBoarding = async (placement, automationId) => {
       },
     ),
   ]);
-  creatOrUpdatePartnerRecord({
+  return db.Partner.upsert({
     partnerId,
     name: partnerName,
     slackChannels: {

--- a/server/jobs/onboarding/slack.js
+++ b/server/jobs/onboarding/slack.js
@@ -6,6 +6,22 @@ import { createOrUpdateSlackAutomation } from '../../modules/automations';
 dotenv.config();
 const { SLACK_AVAILABLE_DEVS_CHANNEL_ID, SLACK_RACK_CITY_CHANNEL_ID } = process.env;
 
+const onboardPartnerChannels = (partnerName, fellow, automationId) => Promise.all([
+  findOrCreatePartnerChannel({ name: partnerName }, 'internal', 'onboarding').then(
+    (internalChannel) => {
+      createOrUpdateSlackAutomation({ ...internalChannel, automationId });
+      return internalChannel.channelId;
+    },
+  ),
+  findOrCreatePartnerChannel({ name: partnerName }, 'general', 'onboarding').then(
+    (generalChannel) => {
+      createOrUpdateSlackAutomation({ ...generalChannel, automationId });
+      accessChannel(fellow.email, generalChannel.channelId, 'invite').then(result => createOrUpdateSlackAutomation({ ...result, automationId }));
+      return generalChannel.channelId;
+    },
+  ),
+]);
+
 /**
  * @desc Automates developer onboarding on slack
  *
@@ -19,21 +35,11 @@ const slackOnBoarding = async (placement, automationId) => {
   const { client_name: partnerName, client_id: partnerId } = placement;
   accessChannel(fellow.email, SLACK_AVAILABLE_DEVS_CHANNEL_ID, 'kick').then(response => createOrUpdateSlackAutomation({ ...response, automationId }));
   accessChannel(fellow.email, SLACK_RACK_CITY_CHANNEL_ID, 'invite').then(response => createOrUpdateSlackAutomation({ ...response, automationId }));
-  const [internalChannelId, generalChannelId] = await Promise.all([
-    findOrCreatePartnerChannel({ name: partnerName }, 'internal', 'onboarding').then(
-      (internalChannel) => {
-        createOrUpdateSlackAutomation({ ...internalChannel, automationId });
-        return internalChannel.channelId;
-      },
-    ),
-    findOrCreatePartnerChannel({ name: partnerName }, 'general', 'onboarding').then(
-      (generalChannel) => {
-        createOrUpdateSlackAutomation({ ...generalChannel, automationId });
-        accessChannel(fellow.email, generalChannel.channelId, 'invite').then(result => createOrUpdateSlackAutomation({ ...result, automationId }));
-        return generalChannel.channelId;
-      },
-    ),
-  ]);
+  const [internalChannelId, generalChannelId] = await onboardPartnerChannels(
+    partnerName,
+    fellow,
+    automationId,
+  );
   return db.Partner.upsert({
     partnerId,
     name: partnerName,

--- a/server/jobs/onboarding/slack.js
+++ b/server/jobs/onboarding/slack.js
@@ -6,6 +6,16 @@ import { createOrUpdateSlackAutomation } from '../../modules/automations';
 dotenv.config();
 const { SLACK_AVAILABLE_DEVS_CHANNEL_ID, SLACK_RACK_CITY_CHANNEL_ID } = process.env;
 
+/**
+ *@desc Perform onboarding automations for partner internal and general channels
+ *
+ * @param {String} partnerName The name of the partner in the engagement
+ * @param {Object} fellow Details of the fellow to be onboarded in the engagement
+ * @param {Number} automationId ID of the automation being carried out
+ *
+ * @returns {Promise} Promise to return an array of channelIds of the
+ * channels(internal and general) used in automation
+ */
 const onboardPartnerChannels = (partnerName, fellow, automationId) => Promise.all([
   findOrCreatePartnerChannel({ name: partnerName }, 'internal', 'onboarding').then(
     (internalChannel) => {
@@ -28,7 +38,7 @@ const onboardPartnerChannels = (partnerName, fellow, automationId) => Promise.al
  * @param {object} placement Placement record whose developer is to be onboarded
  * @param {Number} automationId ID of the automation being carried out
  *
- * @returns {undefined}
+ * @returns {Promise} Promise to return upserted partner details after automation
  */
 const slackOnBoarding = async (placement, automationId) => {
   const { fellow } = placement;

--- a/server/mockAndelaApi/index.js
+++ b/server/mockAndelaApi/index.js
@@ -3,6 +3,8 @@ import faker from 'faker';
 import mockPlacement from './mockPlacement';
 import { slackClient } from '../modules/slack/slackIntegration';
 
+require('dotenv').config();
+
 const router = express.Router();
 
 const { list } = slackClient.users;
@@ -18,11 +20,11 @@ async function generatePlacements(status) {
   const placements = [];
   const { members } = await list();
   const emails = members.reduce(
-    (result, { deleted, profile: { email } }) => (email && !deleted && email !== 'esa@andela.com' ? [...result, email] : result),
+    (result, { deleted, profile: { email } }) => (email && !deleted && email !== process.env.SLACK_ADMIN ? [...result, email] : result),
     [],
   );
-  // max: 3, min: 1
-  for (let index = 0; index < Math.floor(Math.random() * 3) + 1; index++) {
+  // max: 2, min: 1
+  for (let index = 0; index < Math.floor(Math.random() * 2) + 1; index++) {
     placements.push(await mockPlacement(status, emails[faker.random.number(emails.length - 1)]));
   }
   return placements;

--- a/server/mockAndelaApi/index.js
+++ b/server/mockAndelaApi/index.js
@@ -14,7 +14,7 @@ const { list } = slackClient.users;
  *
  * @param {String} status The status of the placement to generate
  *
- * @returns {Array} The list of placements generated
+ * @returns {Promise} Promise to return a list of placements generated
  */
 async function generatePlacements(status) {
   const placements = [];

--- a/server/mockAndelaApi/index.js
+++ b/server/mockAndelaApi/index.js
@@ -23,8 +23,8 @@ async function generatePlacements(status) {
     (result, { deleted, profile: { email } }) => (email && !deleted && email !== process.env.SLACK_ADMIN ? [...result, email] : result),
     [],
   );
-  // max: 2, min: 1
-  for (let index = 0; index < Math.floor(Math.random() * 2) + 1; index++) {
+  // max: 1, min: 1
+  for (let index = 0; index < Math.floor(Math.random() * 1) + 1; index++) {
     placements.push(await mockPlacement(status, emails[faker.random.number(emails.length - 1)]));
   }
   return placements;

--- a/server/mockAndelaApi/mockPlacement.js
+++ b/server/mockAndelaApi/mockPlacement.js
@@ -1,10 +1,9 @@
 import faker from 'faker';
 import axios from 'axios';
-import dotenv from 'dotenv';
 import { promisify } from 'util';
 import client from '../helpers/redis';
 
-dotenv.config();
+require('dotenv').config();
 
 export const redis = {
   set: promisify(client.set).bind(client),
@@ -21,7 +20,7 @@ axios.defaults.headers.common = { 'api-token': process.env.ANDELA_ALLOCATIONS_AP
 export async function getAndelaPartners() {
   const partners = await redis.get('andela-partners');
   if (!partners) {
-    const { data } = await axios.get(`${process.env.ANDELA_PARTNERS}/?limit=100`);
+    const { data } = await axios.get(`${process.env.ANDELA_PARTNERS}?limit=100`);
     await redis.set('andela-partners', JSON.stringify(data.values));
     return data.values;
   }

--- a/server/mockAndelaApi/mockPlacement.js
+++ b/server/mockAndelaApi/mockPlacement.js
@@ -1,14 +1,8 @@
 import faker from 'faker';
 import axios from 'axios';
-import { promisify } from 'util';
-import client from '../helpers/redis';
+import { redisdb } from '../helpers/redis';
 
 require('dotenv').config();
-
-export const redis = {
-  set: promisify(client.set).bind(client),
-  get: promisify(client.get).bind(client),
-};
 
 // Axios authorization header setup
 axios.defaults.headers.common = { 'api-token': process.env.ANDELA_ALLOCATIONS_API_TOKEN };
@@ -18,10 +12,10 @@ axios.defaults.headers.common = { 'api-token': process.env.ANDELA_ALLOCATIONS_AP
  * @returns {Promise} A promise to return a list of andela partners
  */
 export async function getAndelaPartners() {
-  const partners = await redis.get('andela-partners');
+  const partners = await redisdb.get('andela-partners');
   if (!partners) {
-    const { data } = await axios.get(`${process.env.ANDELA_PARTNERS}?limit=100`);
-    await redis.set('andela-partners', JSON.stringify(data.values));
+    const { data } = await axios.get(`${process.env.ANDELA_PARTNERS}?limit=10`);
+    await redisdb.set('andela-partners', JSON.stringify(data.values));
     return data.values;
   }
   return JSON.parse(partners);

--- a/server/models/partner.js
+++ b/server/models/partner.js
@@ -1,9 +1,19 @@
 export default (sequelize, DataTypes) => {
-  const Partner = sequelize.define('partners', {
-    freckleProjectId: DataTypes.STRING,
-    name: DataTypes.STRING,
-    partnerId: DataTypes.STRING,
-    slackChannels: DataTypes.JSON,
-  });
+  const Partner = sequelize.define(
+    'partners',
+    {
+      freckleProjectId: DataTypes.STRING,
+      name: DataTypes.STRING,
+      partnerId: DataTypes.STRING,
+      slackChannels: DataTypes.JSON,
+    },
+    {
+      setterMethods: {
+        id(value) {
+          this.setDataValue('partnerId', value);
+        },
+      },
+    },
+  );
   return Partner;
 };

--- a/server/models/partner.js
+++ b/server/models/partner.js
@@ -4,7 +4,7 @@ export default (sequelize, DataTypes) => {
     {
       freckleProjectId: DataTypes.STRING,
       name: DataTypes.STRING,
-      partnerId: DataTypes.STRING,
+      partnerId: { type: DataTypes.STRING, allowNull: false, unique: true },
       slackChannels: DataTypes.JSON,
     },
     {

--- a/server/models/slackAutomation.js
+++ b/server/models/slackAutomation.js
@@ -9,7 +9,7 @@ export default (sequelize, DataTypes) => {
       slackUserId: DataTypes.STRING,
       type: {
         type: DataTypes.ENUM,
-        values: ['create', 'kick', 'invite'],
+        values: ['create', 'kick', 'invite', 'retrieve'],
         allowNull: false,
       },
     }),

--- a/server/modules/automations.js
+++ b/server/modules/automations.js
@@ -1,7 +1,5 @@
-import sequelize from 'sequelize';
 import db from '../models';
 
-const { Op } = sequelize;
 const {
   SlackAutomation, EmailAutomation, FreckleAutomation, Partner,
 } = db;
@@ -26,27 +24,7 @@ const {
 export const createOrUpdateSlackAutomation = automationDetails => SlackAutomation.upsertById(automationDetails);
 
 /**
- * @func getSlackAutomation
- * @desc Get an already created slackAutomation from the database.
- * Either the channelName or the slackAutomationId should be provided for this operation.
- *
- * @param {object} automationDetails Details about the slack automation to be fetched
- * @param {string} [automationDetails.channelName] Name of the created slack channel
- * @param {string} [automationDetails.slackAutomationId] ID of existing slackAutomation.
- *
- * @return {Promise} Promise that resolves the fetched slackAutomation.
- */
-export const getSlackAutomation = (automationDetails) => {
-  const { slackAutomationId, channelName } = automationDetails;
-  return SlackAutomation.find({
-    where: {
-      [Op.or]: [{ id: slackAutomationId }, { channelName }],
-    },
-  });
-};
-
-/**
- * @func createOrUpdateEmaillAutomation
+ * @func createOrUpdateEmailAutomation
  * @desc create or update an emailAutomation in the Database.
  *
  * @param {object} automationDetails Details about the email automation to be created
@@ -63,7 +41,7 @@ export const getSlackAutomation = (automationDetails) => {
  * @return {Promise} Promise that resolves the created/updated emailAutomation.
  */
 // eslint-disable-next-line max-len
-export const createOrUpdateEmaillAutomation = automationDetails => EmailAutomation.upsertById(automationDetails);
+export const createOrUpdateEmailAutomation = automationDetails => EmailAutomation.upsertById(automationDetails);
 
 /**
  * @func createOrUpdateFreckleAutomation
@@ -114,4 +92,4 @@ export const creatOrUpdatePartnerRecord = async (partnerDetails) => {
  * @param {string} partnerId The id of the partner(from the placement data).
  * @returns {Promise} Promise that resolves to the found partner record.
  */
-export const getPartnerRecord = partnerId => Partner.find({ where: { partnerId } });
+export const getPartnerRecord = partnerId => Partner.findOne({ where: { partnerId } });

--- a/server/modules/automations.js
+++ b/server/modules/automations.js
@@ -1,8 +1,6 @@
 import db from '../models';
 
-const {
-  SlackAutomation, EmailAutomation, FreckleAutomation, Partner,
-} = db;
+const { SlackAutomation, EmailAutomation, FreckleAutomation } = db;
 
 /**
  * @func createOrUpdateSlackAutomation
@@ -18,7 +16,7 @@ const {
  * @param {string} [automationDetails.id] ID of existing slackAutomation.
  * For updating purpose alone.
  *
- * @return {Promise} Promise that resolves the created/updated slackAutomation.
+ * @return {Promise} Promise to return the created/updated slackAutomation.
  */
 // eslint-disable-next-line max-len
 export const createOrUpdateSlackAutomation = automationDetails => SlackAutomation.upsertById(automationDetails);
@@ -38,7 +36,7 @@ export const createOrUpdateSlackAutomation = automationDetails => SlackAutomatio
  * @param {string} [automationDetails.id] ID of existing emailAutomation.
  * For updating purpose alone.
  *
- * @return {Promise} Promise that resolves the created/updated emailAutomation.
+ * @return {Promise} Promise to return the created/updated emailAutomation.
  */
 // eslint-disable-next-line max-len
 export const createOrUpdateEmailAutomation = automationDetails => EmailAutomation.upsertById(automationDetails);
@@ -57,16 +55,7 @@ export const createOrUpdateEmailAutomation = automationDetails => EmailAutomatio
  * @param {string} [automationDetails.id] ID of existing freckleAutomation.
  * For updating purpose alone.
  *
- * @returns {Promise} Promise that resolves to the created/updated freckleAutomation.
+ * @returns {Promise} Promise to return the created/updated freckleAutomation.
  */
 // eslint-disable-next-line max-len
 export const createOrUpdateFreckleAutomation = automationDetails => FreckleAutomation.upsertById(automationDetails);
-
-/**
- * @func getPartnerRecord
- * @desc Get a partner record from the database
- *
- * @param {string} partnerId The id of the partner(from the placement data).
- * @returns {Promise} Promise that resolves to the found partner record.
- */
-export const getPartnerRecord = partnerId => Partner.findOne({ where: { partnerId } });

--- a/server/modules/automations.js
+++ b/server/modules/automations.js
@@ -63,29 +63,6 @@ export const createOrUpdateEmailAutomation = automationDetails => EmailAutomatio
 export const createOrUpdateFreckleAutomation = automationDetails => FreckleAutomation.upsertById(automationDetails);
 
 /**
- * @func creatOrUpdatePartnerRecord
- * @desc create or update a partner record in the database
- *
- * @param {object} partnerDetails The partner details
- * @param {string} partnerDetails.name Name of partner
- * @param {string} partnerDetails.partnerId Id of partner from allocations
- * @param {string} partnerDetails.freckleProjectId The partner freckle project ID
- * @param {object} partnerDetails.slackChannels The partner slack channels
- * @param {string} partnerDetails.slackChannels.internal The partner internal slack channel
- * @param {string} partnerDetails.slackChannels.general The partner general slack channel
- *
- * @returns {Promise} Promise that resolves to the created/updated partner record
- */
-export const creatOrUpdatePartnerRecord = async (partnerDetails) => {
-  const { partnerId } = partnerDetails;
-  const existingRecord = await db.Partner.find({ where: { partnerId } });
-  if (existingRecord) {
-    return db.Partner.update(partnerDetails, { where: { partnerId } });
-  }
-  return db.Partner.create(partnerDetails);
-};
-
-/**
  * @func getPartnerRecord
  * @desc Get a partner record from the database
  *

--- a/server/modules/slack/slackIntegration.js
+++ b/server/modules/slack/slackIntegration.js
@@ -1,92 +1,135 @@
 import { WebClient } from '@slack/client';
 import dotenv from 'dotenv';
+import util from 'util';
 import makeChannelNames from '../../helpers/slackHelpers';
-import { getSlackAutomation } from '../automations';
+import client from '../../helpers/redis';
 
 dotenv.config();
+const { SCAN_RANGE, REJECT_RATE_LIMIT, SLACK_TOKEN } = process.env;
 let rejectRateLimit = false;
-if (typeof process.env.REJECT_RATE_LIMIT !== 'undefined') {
-  rejectRateLimit = process.env.REJECT_RATE_LIMIT;
+if (typeof REJECT_RATE_LIMIT !== 'undefined') {
+  rejectRateLimit = REJECT_RATE_LIMIT;
 }
-const { SLACK_TOKEN } = process.env;
 export const slackClient = new WebClient(SLACK_TOKEN, {
   rejectRateLimitCalls: rejectRateLimit,
   retryConfig: {
-    retries: 0,
+    retries: 1,
     minTimeout: 10 * 1000,
     maxTimeout: 10 * 1000,
   },
 });
-
-const channelData = channelName => ({
-  slackUserId: null,
-  channelName,
-  type: 'create',
-  status: 'success',
-  statusMessage: `${channelName} slack channel created`,
-});
-
-/**
- * @func getExistingChannel
- * @desc Get an existing slack channel(from the database)
- * @param {string} channelName The name of the slack channel to get
- *
- * @returns {object} An object that would always contain
- * a truthy value "channelExist" to tell if the channel exist or not.
- */
-const getExistingChannel = async (channelName) => {
-  let channelExists = false;
-  let channelId = null;
-  const result = await getSlackAutomation({ channelName });
-  if (result) {
-    channelExists = true;
-    ({ channelId } = result);
-  }
-  return { channelExists, channelId };
-};
+const scanKeys = util.promisify(client.scan).bind(client);
+const setItem = util.promisify(client.set).bind(client);
+const getItem = util.promisify(client.get).bind(client);
 
 /**
  * @func createChannel
  * @desc Create a slack channel(and store it in the database)
  *
- * @param {string} channelName The name of the channel to be created.
+ * @param {Object} channelDetails The details of the channel to be created
  * @returns {object} The details of the slack channel created.
  */
-const createChannel = async (channelName) => {
-  const data = channelData(channelName);
+const createChannel = async (channelDetails) => {
+  const data = { ...channelDetails };
   try {
-    const result = await slackClient.groups.create({ name: channelName });
-    data.channelId = result.group.id;
+    const { group } = await slackClient.groups.create({ name: data.channelName });
+    setItem(group.name, JSON.stringify(group));
+    data.channelId = group.id;
     return data;
   } catch (error) {
     data.status = 'failure';
     data.statusMessage = error.message;
-    let channelId;
-    if (error.data && error.data.error === 'name_taken') {
-      ({ channelId = null } = await getExistingChannel(data.channelName));
-    }
-    data.channelId = channelId;
     return data;
   }
 };
 
 const automationData = (partnerName, channelType) => {
   const channelName = makeChannelNames(partnerName, channelType);
-  return channelData(channelName);
+  return {
+    slackUserId: null,
+    channelName,
+    status: 'success',
+  };
+};
+
+const findChannels = async (options, channelName, { response_metadata: metaData, channels }) => {
+  // Check if channel name matches any in results of the current page
+  const matchedChannels = channels.reduce((list, channel) => {
+    setItem(channel.name, JSON.stringify(channel));
+    if (channel.name.includes(channelName)) list.push(channel);
+    return list;
+  }, []);
+  if (matchedChannels.length) return matchedChannels;
+  // When a `next_cursor` exists, recursively call this function to get the next page.
+  if (metaData && metaData.next_cursor && metaData.next_cursor.length) {
+    // Make a copy of options
+    const pageOptions = { ...options };
+    // Add the `cursor` argument
+    pageOptions.cursor = metaData.next_cursor;
+    return findChannels(options, channelName, await slackClient.conversations.list(pageOptions));
+  }
+  // Otherwise, we're done, channel not found
+  return [];
+};
+
+const getMatchingChannels = async (channelName, actual = null) => {
+  const name = actual ? channelName : channelName.slice(0, 7);
+  const [, result] = await scanKeys(0, 'match', `*${name}*`, 'count', SCAN_RANGE);
+  if (!result.length) {
+    const options = { limit: 999, exclude_archived: true, types: 'public_channel,private_channel' };
+    return findChannels(options, name, await slackClient.conversations.list(options));
+  }
+  return result;
 };
 
 /**
- * @function createPartnerChannel
+ * @function findOrCreatePartnerChannel
  * @desc Create slack channels for a partner engagement
  *
- * @param {string} partnerName Name of the partner
- * @param {string} channelType The type of channel: internal || general
+ * @param {Object} partnerData Details of the partner
+ * @param {String} channelType The type of channel: internal || general
+ * @param {String} jobType The type of job being executed: onboarding || offboarding
  *
  * @returns {Object} An object containing details of the created channels
  */
-export const createPartnerChannel = async (partnerName, channelType) => {
-  const data = automationData(partnerName, channelType);
-  return createChannel(data.channelName);
+export const findOrCreatePartnerChannel = async (partnerData, channelType, jobType) => {
+  const data = automationData(partnerData.name, channelType);
+  let result;
+  if (partnerData.channel_name && partnerData.channel_name.length) {
+    data.channelName = partnerData.channel_name.slice(0, -4);
+    result = await getMatchingChannels(data.channelName, true);
+  } else {
+    result = await getMatchingChannels(data.channelName);
+  }
+  let existingChannel;
+  if (result.length) {
+    result = result.find((channel) => {
+      const searchKey = channel.name ? channel.name.slice(-4) : channel.slice(-4);
+      return channelType === 'general' ? searchKey !== '-int' : searchKey === '-int';
+    });
+    if (result) {
+      existingChannel = result.name ? result : JSON.parse(await getItem(result));
+    }
+  }
+  if (existingChannel) {
+    return {
+      ...data,
+      channelName: existingChannel.name,
+      channelId: existingChannel.id,
+      type: 'retrieve',
+      statusMessage: `${existingChannel.name} slack channel retrieved`,
+    };
+  }
+  if (jobType === 'onboarding') {
+    data.type = 'create';
+    data.statusMessage = `${data.channelName} slack channel created`;
+    return createChannel(data);
+  }
+  return {
+    ...data,
+    status: 'failure',
+    statusMessage: 'Could not find partner channel for the offboarding',
+  };
 };
 
 /**

--- a/test/endpoints/automations.test.js
+++ b/test/endpoints/automations.test.js
@@ -196,7 +196,7 @@ describe('Tests for automation endpoints\n', () => {
         expect(res.body)
           .to.have.property('automation')
           .to.have.property('total')
-          .to.be.equal(0);
+          .to.be.be.a('Number');
         done();
       });
   });
@@ -209,7 +209,7 @@ describe('Tests for automation endpoints\n', () => {
         expect(res.body)
           .to.have.property('automation')
           .to.have.property('total')
-          .to.be.equal(0);
+          .to.be.be.a('Number');
         done();
       });
   });

--- a/test/helpers/helpers.test.js
+++ b/test/helpers/helpers.test.js
@@ -3,7 +3,8 @@ import axios from 'axios';
 import response from '../../server/helpers/response';
 import { getMailInfo, checkFailureCount } from '../../server/jobs/helpers';
 import { automationData } from '../../server/jobs';
-import { redis, getAndelaPartners } from '../../server/mockAndelaApi/mockPlacement';
+import { redisdb } from '../../server/helpers/redis';
+import { getAndelaPartners } from '../../server/mockAndelaApi/mockPlacement';
 
 import * as allocation from '../../server/modules/allocations';
 import { samplePartner } from '../mocks/partners';
@@ -50,7 +51,7 @@ describe('Test that helper functions work as expected', () => {
   });
   it('Should return list of mock partners from radis', async () => {
     const getFromRadis = sinon
-      .stub(redis, 'get')
+      .stub(redisdb, 'get')
       .callsFake(() => JSON.stringify(samplePartner.data.values));
     const axiosGetPartners = sinon.spy(axios, 'get');
     const partners = await getAndelaPartners();
@@ -62,8 +63,8 @@ describe('Test that helper functions work as expected', () => {
     axiosGetPartners.restore();
   });
   it('Should return list of mock partners from staging-api', async () => {
-    const getFromRadis = sinon.stub(redis, 'get').callsFake(() => null);
-    const saveToRadis = sinon.spy(redis, 'set');
+    const getFromRadis = sinon.stub(redisdb, 'get').callsFake(() => null);
+    const saveToRadis = sinon.spy(redisdb, 'set');
     const axiosGetPartners = sinon.stub(axios, 'get').callsFake(() => samplePartner);
 
     const partners = await getAndelaPartners();

--- a/test/jobs/executejobs.test.js
+++ b/test/jobs/executejobs.test.js
@@ -1,12 +1,14 @@
 import sinon from 'sinon';
 import executejobs from '../../server/jobs';
 import { io } from '../../server';
+import { redisdb } from '../../server/helpers/redis';
 
 const fakeIoEmit = sinon.spy(io, 'emit');
 
 describe('Jobs Execution Test Suite', async () => {
   it('should execute onboarding jobs successfully', async () => {
-    // get automations from db and test that parent data matches the newPlacements
+    // get automations from db and assert that parent data matches the newPlacements
+    await redisdb.delete('andela-partners');
     await executejobs('onboarding');
     sinon.assert.called(fakeIoEmit);
     fakeIoEmit.restore();

--- a/test/mocks/partners.js
+++ b/test/mocks/partners.js
@@ -1,4 +1,9 @@
-export const stringifiedPartners = '{"values":[{"id":"ABCDEFZYXWVU","name":"Sample Partner","location":"San Francisco California, United States","salesforce_id":"012345ABCDEF","onboarding_specialist":"n/a","director_of_success":"","technical_success_manager":"","client_experience_lead":"John Doe","client_executive":"John Doe","start_date":"","end_date":"","updated_at":"2017-11-30T21:14:54.291Z","created_at":"2017-07-28T14:22:28.000Z","status":"Onboarding Partner","health":[],"description":"","client_size":"","technical_coordinator":"","channel_id":"","channel_name":"","type":"Onboarding","technical_success_manager_id":"","director_of_success_id":""}]}';
+export const stringifiedPartner = '{"id":"ABCDEFZYXWVU","name":"Sample Partner","location":"San '
+  + 'Francisco California, United '
+  + 'States","salesforce_id":"012345ABCDEF","onboarding_specialist":"n/a","director_of_success":"","technical_success_manager":"","client_experience_lead":"John '
+  + 'Doe","client_executive":"John '
+  + 'Doe","start_date":"","end_date":"","updated_at":"2017-11-30T21:14:54.291Z","created_at":"2017-07-28T14:22:28.000Z","status":"Onboarding '
+  + 'Partner","health":[],"description":"","client_size":"","technical_coordinator":"","channel_id":"","channel_name":"","type":"Onboarding","technical_success_manager_id":"","director_of_success_id":""}';
 export const samplePartner = {
   data: {
     values: [

--- a/test/mocks/slack.js
+++ b/test/mocks/slack.js
@@ -36,13 +36,13 @@ const slackMocks = {
   slackUser: {
     ok: true,
     user: {
-      id: 'UDABCDEFG',
+      id: 'UJ25QA667',
       team_id: 'TDG6WMQCF',
       name: 'John',
       deleted: false,
       color: 'e0a729',
-      real_name: 'John Doe',
-      tz: 'Africa/Nairobi',
+      real_name: 'Ebele Nsoffor',
+      tz: 'Africa/Lagos',
       tz_label: 'East Africa Time',
       tz_offset: 10800,
       profile: {
@@ -57,7 +57,7 @@ const slackMocks = {
         status_emoji: '',
         status_expiration: 0,
         avatar_hash: 'g380c211d1dd',
-        email: 'johndoe@mail.com',
+        email: 'ebelensoffor@gmail.com',
       },
       is_admin: false,
       is_owner: false,
@@ -111,7 +111,7 @@ const slackMocks = {
   },
   groupInfo: {
     ok: true,
-    group: {
+    channel: {
       id: 'GBRR4B5E3',
       name: 'rack-city',
       is_group: true,

--- a/test/modules/automation.test.js
+++ b/test/modules/automation.test.js
@@ -42,24 +42,6 @@ describe('Automation Database Operations', () => {
     await automations.createOrUpdateSlackAutomation(automationDetails);
     expect(mockModels.SlackAutomation.upsertById.calledWith(automationDetails)).to.be.true;
   });
-  it('should get a slackAutomation record from the DB', async () => {
-    const automationDetails = {
-      slackAutomationId: '99',
-      channelName: 'p-test',
-      // ...other properties...
-    };
-    await automations.getSlackAutomation(automationDetails);
-    expect(
-      mockModels.SlackAutomation.find.calledWith({
-        where: {
-          [Op.or]: [
-            { id: automationDetails.slackAutomationId },
-            { channelName: automationDetails.channelName },
-          ],
-        },
-      }),
-    ).to.be.true;
-  });
   it('should upsert an emailAutomation record in the DB', async () => {
     const automationDetails = {
       automationId: '3',

--- a/test/modules/automation.test.js
+++ b/test/modules/automation.test.js
@@ -53,7 +53,7 @@ describe('Automation Database Operations', () => {
       status: 'success',
       statusMessage: 'Email sent succesfully',
     };
-    await automations.createOrUpdateEmaillAutomation(automationDetails);
+    await automations.createOrUpdateEmailAutomation(automationDetails);
     expect(mockModels.EmailAutomation.upsertById.calledWith(automationDetails)).to.be.true;
     expect(mockModels.EmailAutomation.upsertById.firstCall.args[0].statusMessage).to.equal(
       'Email sent succesfully',
@@ -65,25 +65,5 @@ describe('Automation Database Operations', () => {
     };
     await automations.createOrUpdateFreckleAutomation(automationDetails);
     expect(mockModels.FreckleAutomation.upsertById.calledWith(automationDetails)).to.be.true;
-  });
-  it('should get a partner record from the DB', async () => {
-    const partnerId = '-UTF56K';
-    await automations.getPartnerRecord(partnerId);
-    expect(mockModels.Partner.find.calledWith({ where: { partnerId } })).to.be.true;
-  });
-  it('should create or update a partner record in database', async () => {
-    const partner = {
-      name: 'Facebook Inc',
-      partnerId: 'JKb533jksdf_iu34',
-      freckleProjectId: '349icnioj3in_23',
-      slackChannels: {
-        internal: 'facebook-int',
-        general: 'facebook',
-      },
-    };
-    await automations.creatOrUpdatePartnerRecord(partner);
-    expect(mockModels.Partner.find.calledWith({ where: { partnerId: partner.partnerId } })).to.be
-      .true;
-    expect(mockModels.Partner.create.calledWith(partner)).to.be.true;
   });
 });

--- a/test/modules/slackIntegration.spec.js
+++ b/test/modules/slackIntegration.spec.js
@@ -15,10 +15,10 @@ const fakeSlackClient = {
   lookupByEmail: sinon
     .stub(slack.slackClient.users, 'lookupByEmail')
     .callsFake(() => slackMocks.slackUser),
-  invite: sinon.stub(slack.slackClient.groups, 'invite').callsFake(() => slackMocks.inviteUser),
-  kick: sinon.stub(slack.slackClient.groups, 'kick').callsFake(() => slackMocks.removeUser),
+  invite: sinon.stub(slack.slackClient.conversations, 'invite').callsFake(() => slackMocks.inviteUser),
+  kick: sinon.stub(slack.slackClient.conversations, 'kick').callsFake(() => slackMocks.removeUser),
   create: sinon.stub(slack.slackClient.groups, 'create').callsFake(() => slackMocks.createGroups),
-  groupInfo: sinon.stub(slack.slackClient.groups, 'info').callsFake(() => slackMocks.groupInfo),
+  info: sinon.stub(slack.slackClient.conversations, 'info').callsFake(() => slackMocks.groupInfo),
 };
 
 /* eslint-disable no-unused-expressions */
@@ -32,7 +32,11 @@ describe('Slack Integration Test Suite', async () => {
   it('Should create internal slack channels and save the automation to DB', async () => {
     const { data } = onboardingAllocations;
     const { client_name: partnerName } = data.values[0];
-    const createResult = await slack.findOrCreatePartnerChannel({ name: partnerName }, 'internal');
+    const createResult = await slack.findOrCreatePartnerChannel(
+      { name: partnerName },
+      'internal',
+      'onboarding',
+    );
     const expectedResult = {
       id: slackMocks.createGroups.group.id,
       name: slackMocks.createGroups.group.name,
@@ -41,30 +45,35 @@ describe('Slack Integration Test Suite', async () => {
     expect(createResult.channelId).to.equal(expectedResult.id);
     expect(createResult.channelName).to.equal(`${expectedResult.name}-int`);
   });
-  it('Should create general slack channels and save the automation to DB', async () => {
+  it('Should retrieve general slack channels', async () => {
     const { data } = onboardingAllocations;
     const { client_name: partnerName } = data.values[0];
-    const createResult = await slack.findOrCreatePartnerChannel({ name: partnerName }, 'general');
+    const createResult = await slack.findOrCreatePartnerChannel(
+      { name: partnerName },
+      'general',
+      'onboarding',
+    );
     const expectedResult = {
       id: slackMocks.createGroups.group.id,
       name: slackMocks.createGroups.group.name,
     };
-    expect(fakeSlackClient.create.calledOnce).to.be.true;
+    expect(fakeSlackClient.create.calledOnce).to.be.false;
     expect(createResult.channelId).to.equal(expectedResult.id);
     expect(createResult.channelName).to.equal(expectedResult.name);
+    expect(createResult.type).to.equal('retrieve');
   });
   it('Should add developers to respective channels and save the automation to DB', async () => {
-    const email = 'johndoe@mail.com';
-    const channel = 'GBRR4B5E3';
+    const email = 'ebelensoffor@gmail.com';
+    const channel = 'CJFG3JWCX';
     await slack.accessChannel(email, channel, 'invite');
     expect(fakeSlackClient.invite.calledOnce).to.be.true;
-    expect(fakeSlackClient.groupInfo.calledOnce).to.be.true;
+    expect(fakeSlackClient.info.calledOnce).to.be.true;
   });
   it('Should remove developers from channels and save the automation to DB', async () => {
-    const email = 'johndoe@mail.com';
-    const channel = 'GBRR4B5E3';
+    const email = 'ebelensoffor@gmail.com';
+    const channel = 'CJFG3JWCX';
     await slack.accessChannel(email, channel, 'kick');
     expect(fakeSlackClient.kick.calledOnce).to.be.true;
-    expect(fakeSlackClient.groupInfo.calledOnce).to.be.true;
+    expect(fakeSlackClient.info.calledOnce).to.be.true;
   });
 });

--- a/test/modules/slackIntegration.spec.js
+++ b/test/modules/slackIntegration.spec.js
@@ -4,12 +4,10 @@ import onboardingAllocations from '../mocks/allocations';
 import slackMocks from '../mocks/slack';
 
 const createOrUpdateSlackAutomation = sinon.stub();
-const getSlackAutomation = sinon.stub();
 
 const slack = proxyquire('../../server/modules/slack/slackIntegration', {
   '../automations': {
     createOrUpdateSlackAutomation,
-    getSlackAutomation,
   },
 });
 
@@ -29,13 +27,12 @@ describe('Slack Integration Test Suite', async () => {
   beforeEach(() => {
     Object.keys(fakeSlackClient).forEach(fake => fakeSlackClient[fake].resetHistory());
     createOrUpdateSlackAutomation.resetHistory();
-    getSlackAutomation.resetHistory();
   });
 
   it('Should create internal slack channels and save the automation to DB', async () => {
     const { data } = onboardingAllocations;
     const { client_name: partnerName } = data.values[0];
-    const createResult = await slack.createPartnerChannel(partnerName, 'internal');
+    const createResult = await slack.findOrCreatePartnerChannel({ name: partnerName }, 'internal');
     const expectedResult = {
       id: slackMocks.createGroups.group.id,
       name: slackMocks.createGroups.group.name,
@@ -47,7 +44,7 @@ describe('Slack Integration Test Suite', async () => {
   it('Should create general slack channels and save the automation to DB', async () => {
     const { data } = onboardingAllocations;
     const { client_name: partnerName } = data.values[0];
-    const createResult = await slack.createPartnerChannel(partnerName, 'general');
+    const createResult = await slack.findOrCreatePartnerChannel({ name: partnerName }, 'general');
     const expectedResult = {
       id: slackMocks.createGroups.group.id,
       name: slackMocks.createGroups.group.name,


### PR DESCRIPTION
#### What does this PR do?
Ensure partner records with respective slack channels are saved during automation

#### Description of Task to be completed?
- redefine `createPartnerChannel` to `findOrCreatePartnerChannel`
- add `retrieve` enum key to slackAutomation type field
- redefine `updatePartnerStore` to `getPartnerFromStore`
- reimplement `findPartnerById` to ensure returned partner has slack details
- refactor slackOnboarding job for speed

#### How should this be manually tested?
1. On terminal, run command: `npm run start:dev`
2. Confirm that the partner details are saved for each client_id in the automation
3. Check slack automations to confirm that all off-boarding jobs are successful

#### Any background context you want to provide?
- When an off-boarding automation is to be carried, the automation fails because the partner is not found in database especially when the off-boarding placement was not automated by ESA, hence not having any slack channels to use in `kicking` the developer
- Even when partner detail is found, slack automation still fails because of absence of general slack channelId in the saved partner record

#### What are the relevant pivotal tracker stories?
[#165083767](https://www.pivotaltracker.com/story/show/165083767)

#### Postman Documentation
N/A
