### PR TITLE
Ft add search for partner or fellow 165119707

### DIFF
--- a/server/controllers/automationController.js
+++ b/server/controllers/automationController.js
@@ -118,7 +118,6 @@ const dateQueryFunc = (date = { to: new Date() }) => {
 const filterQuery = (dateQuery, slackAutomation, emailAutomation, freckleAutomation, type, search) => {
   let myQueryCounter = queryCounter + addSearchQuery(search);
   let automationRawQuery = sqlAutomationRawQuery + addSearchQuery(search);
-  console.log(automationRawQuery, myQueryCounter);
   if (slackAutomation) {
     automationRawQuery += 'AND "s"."status" = 0 ';
     myQueryCounter += 'AND "s"."status" = 0 ';

--- a/test/endpoints/automations.test.js
+++ b/test/endpoints/automations.test.js
@@ -123,4 +123,49 @@ describe('Tests for automation endpoints\n', () => {
         done();
       });
   });
+  it('Should search automation data for partners or fellows name containing a string', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/automations?q=conroy')
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body)
+          .to.have.property('message')
+          .to.equal('Successfully fetched automations');
+        expect(res.body.pagination)
+          .to.have.property('currentPage')
+          .to.be.equal(1);
+        done();
+      });
+  });
+  it('Should search automation with fellow name containing a string', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/automations?q=val&queryType=fellow')
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body)
+          .to.have.property('message')
+          .to.equal('Successfully fetched automations');
+        expect(res.body.pagination)
+          .to.have.property('currentPage')
+          .to.be.equal(1);
+        done();
+      });
+  });
+  it('Should search automation with partner name containing a string', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/automations?q=conroy&queryType=partner')
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body)
+          .to.have.property('message')
+          .to.equal('Successfully fetched automations');
+        expect(res.body.pagination)
+          .to.have.property('currentPage')
+          .to.be.equal(1);
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Adds search

#### Description of Task to be completed?

This adds the ability to search for automations with fellow or partner name containing a string

#### How should this be manually tested?
1. On terminal, run command do
```bash

 curl http:localhost:6050/api/v1/automation?q={searchString}&queryType={partner|fellow}

```
or

On Postman send url http:localhost:6050/api/v1/automation?q={searchString}&queryType={partner|fellow}.

This will return automations with either partner or fellow name containing the **searchString**. If **queryType** is not specified it returns both fellow or partner with name containing the **searchString**

#### What are the relevant pivotal tracker stories?
#165119707

#### Screenshots (If applicable)