### PR TITLE
#165998462 Add time periods for statistics.

### DIFF
--- a/server/controllers/automationStatsController.js
+++ b/server/controllers/automationStatsController.js
@@ -33,13 +33,28 @@ const queryCountResolver = queryCount => Number(queryCount[0].count);
  *
  * @returns {object} response reporting automation stats
  */
+
+const dateSubtractor = (duration) => {
+  const date = duration === 'days'
+    ? 0
+    : 1;
+  return date;
+};
+
 export default async (req, res) => {
-  const date = req.query.date
+  const { duration } = req.query;
+  if (duration !== 'days' && duration !== 'weeks' && duration !== 'months' && duration !== 'years') {
+    return res.status(400).json({ error: 'invalid duration input' });
+  }
+  const dateEnd = req.query.date
     ? moment(req.query.date).format('YYYY-MM-DD')
     : moment().format('YYYY-MM-DD');
+  const dateStart = req.query.date
+    ? moment(req.query.date).subtract(dateSubtractor(duration), duration).format('YYYY-MM-DD')
+    : moment().subtract(dateSubtractor(duration), duration).format('YYYY-MM-DD');
 
   const querySettings = {
-    replacements: [`${date} 00:00:00.00`, `${date} 23:59:59.99`],
+    replacements: [`${dateStart} 00:00:00.00`, `${dateEnd} 23:59:59.99`],
     type: models.sequelize.QueryTypes.SELECT,
   };
   try {

--- a/test/endpoints/automations.test.js
+++ b/test/endpoints/automations.test.js
@@ -190,7 +190,7 @@ describe('Tests for automation endpoints\n', () => {
   it('should return stats of total automations', (done) => {
     chai
       .request(app)
-      .get('/api/v1/automations/stats')
+      .get('/api/v1/automations/stats?duration=days')
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -203,7 +203,7 @@ describe('Tests for automation endpoints\n', () => {
   it('should return stats of total automations of a given date', (done) => {
     chai
       .request(app)
-      .get(`/api/v1/automations/stats?date=${new Date(2018, 4, 1).toISOString()}`)
+      .get(`/api/v1/automations/stats?duration=days&date=${new Date(2018, 4, 1).toISOString()}`)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -213,10 +213,61 @@ describe('Tests for automation endpoints\n', () => {
         done();
       });
   });
+  it('should return stats of total automations of a given week', (done) => {
+    chai
+      .request(app)
+      .get(`/api/v1/automations/stats?duration=weeks&date=${new Date(2018, 4, 1).toISOString()}`)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body)
+          .to.have.property('automation')
+          .to.have.property('total')
+          .to.be.equal(0);
+        done();
+      });
+  });
+  it('should return stats of total automations of a given month', (done) => {
+    chai
+      .request(app)
+      .get(`/api/v1/automations/stats?duration=months&date=${new Date(2018, 4, 1).toISOString()}`)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body)
+          .to.have.property('automation')
+          .to.have.property('total')
+          .to.be.equal(0);
+        done();
+      });
+  });
+  it('should return stats of total automations of a given year', (done) => {
+    chai
+      .request(app)
+      .get(`/api/v1/automations/stats?duration=years&date=${new Date(2018, 4, 1).toISOString()}`)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body)
+          .to.have.property('automation')
+          .to.have.property('total')
+          .to.be.equal(0);
+        done();
+      });
+  });
+  it('should return an error when an invalid duration is input', (done) => {
+    chai
+      .request(app)
+      .get(`/api/v1/automations/stats?duration=invalid&date=${new Date(2018, 4, 1).toISOString()}`)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body)
+          .to.have.property('error')
+          .to.equal('invalid duration input');
+        done();
+      });
+  });
   it('should return stats of onboarding successfull automations', (done) => {
     chai
       .request(app)
-      .get('/api/v1/automations/stats')
+      .get('/api/v1/automations/stats?duration=days')
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)


### PR DESCRIPTION
#### What does this PR do?
- This PR adds a parameter in the statistics URL to enable different time periods to be selected for statistics to be carried out.

#### Description of Task to be completed?
- Add a parameter to the statistics URL
- Enable functionality to get statistics for different time periods

#### How should this be manually tested?
1. Git clone the repository.
2. Checkout to the `ft-add-statistics-period-165998462` branch.
5. Start the server `npm run start:dev` _(or the `yarn` equivalent)_.
6. Clone the frontend repository, `https://github.com/andela/bp-esa-frontend`.
7. Checkout to the frontend `ft-statistics-dropdown-165998462` branch.
8. Start the frontend server `npm run start` _(or the `yarn` equivalent)_.
9. Login to the ESA application
10. Click the caret in the statistics section.
11. Click a time period.
The statistics for the selected time period should be displayed.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[165998462](https://www.pivotaltracker.com/story/show/165998462)

#### Screenshots (If applicable)
<img width="1403" alt="Screen Shot 2019-05-16 at 15 44 56" src="https://user-images.githubusercontent.com/38077368/57854747-a3c60c80-77f1-11e9-9846-3fcfdc198dfd.png">
