### PR TITLE
Migrate/Update partner data before automation starts

### DIFF
--- a/db/migrations/20190606094751-add-partner-location.js
+++ b/db/migrations/20190606094751-add-partner-location.js
@@ -1,0 +1,8 @@
+module.exports = {
+  up: (queryInterface, DataTypes) => queryInterface.addColumn('partners', 'location', {
+    allowNull: false,
+    type: DataTypes.STRING,
+  }),
+
+  down: (queryInterface, DataTypes) => queryInterface.removeColumn('partners', 'location'),
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "NODE_ENV=test nyc --reporter=lcov --reporter=html --reporter=text mocha --recursive test/* --compilers js:@babel/register --require @babel/polyfill --timeout 150000 --exit",
     "lint": "eslint .",
     "migrations": "sequelize db:migrate",
-    "reset-database": "sequelize db:drop && sequelize db:create"
+    "reset-database": "sequelize db:drop && sequelize db:create",
+    "setup": "yarn reset-database && yarn migrations"
   },
   "repository": {
     "type": "git",

--- a/server/jobs/helpers.js
+++ b/server/jobs/helpers.js
@@ -9,7 +9,7 @@ export const count = { FAILED_COUNT_NUMBER: 0 };
  * @param {String} partnerLocation Location of the partner to be used in the automation
  * @returns {Promise} Promise to return info of the mail to be sent
  */
-export const getMailInfo = async (placement, partnerLocation) => {
+export const getMailInfo = (placement, partnerLocation) => {
   const {
     fellow: { name: developerName, email: developerEmail, location: developerLocation },
     client_name: partnerName,

--- a/server/jobs/helpers.js
+++ b/server/jobs/helpers.js
@@ -1,4 +1,3 @@
-import { findPartnerById } from '../modules/allocations';
 import { createOrUpdateEmailAutomation } from '../modules/automations';
 import { sendPlacementFetchAlertEmail } from '../modules/email/emailModule';
 
@@ -7,17 +6,16 @@ export const count = { FAILED_COUNT_NUMBER: 0 };
 /**
  * @desc Retrieves necessary info. to be sent via email for any given placement
  * @param {object} placement A placement instance from allocation
+ * @param {String} partnerLocation Location of the partner to be used in the automation
  * @returns {Promise} Promise to return info of the mail to be sent
  */
-export const getMailInfo = async (placement) => {
+export const getMailInfo = async (placement, partnerLocation) => {
   const {
     fellow: { name: developerName, email: developerEmail, location: developerLocation },
     client_name: partnerName,
-    client_id: partnerId,
     end_date: rollOffDate,
     start_date: dateStart,
   } = placement;
-  const { location: partnerLocation } = await findPartnerById(partnerId);
   return {
     developerName,
     partnerName,
@@ -47,12 +45,13 @@ export const checkFailureCount = async (failCount) => {
  *
  * @param {Array} emailFunctions List of functions to execute for the automation
  * @param {Object} placement Placement data with which to execute automation
+ * @param {String} location Location of partner used in the automation
  * @param {String} automationId Id of the automation being carried out
  *
  * @returns {void}
  */
-export async function executeEmailAutomation(emailFunctions, placement, automationId) {
-  const mailInfo = await getMailInfo(placement);
+export async function executeEmailAutomation(emailFunctions, placement, location, automationId) {
+  const mailInfo = await getMailInfo(placement, location);
   const emailAutomations = await Promise.all(emailFunctions.map(func => func(mailInfo)));
   await Promise.all(
     emailAutomations.map(automationData => createOrUpdateEmailAutomation({ ...automationData, automationId })),

--- a/server/jobs/index.js
+++ b/server/jobs/index.js
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import ms from 'ms';
 import * as Helper from './helpers';
-import { fetchNewPlacements } from '../modules/allocations';
+import { fetchNewPlacements, findPartnerById } from '../modules/allocations';
 import { io } from '..';
 import { formatPayload } from '../utils/formatter';
 import { include } from '../controllers/automationController';
@@ -58,17 +58,22 @@ export const automationData = (placement, type) => {
   };
 };
 
-const automations = async (placement, type, jobList) => {
+const automations = async (placement, partner, type, jobList) => {
   const { placementId, ...defaults } = automationData(placement, type);
   const [{ id: automationId }, created] = await db.Automation.findOrCreate({
     where: { placementId },
     defaults,
   });
   if (created) {
-    await Promise.all(jobList.map(job => job(placement, automationId)));
+    await Promise.all(jobList.map(job => job(placement, partner, automationId)));
     const newAutomation = await db.Automation.findByPk(automationId, { include });
     io.emit('newAutomation', formatPayload(newAutomation));
   }
+};
+
+const automationList = (partnerList, newPlacements, type, jobList) => {
+  const partner = clientId => partnerList.find(({ partnerId }) => partnerId === clientId);
+  return newPlacements.map(placement => automations(placement, partner(placement.client_id), type, jobList));
 };
 
 /**
@@ -91,7 +96,10 @@ export default function executeJobs(type) {
     .then(async (newPlacements) => {
       if (!fetchPlacementError) {
         Helper.count.FAILED_COUNT_NUMBER = 0;
-        await Promise.all(newPlacements.map(placement => automations(placement, type, jobList)));
+        const partnerList = await Promise.all(
+          newPlacements.map(({ client_id: partnerId }) => findPartnerById(partnerId)),
+        );
+        await Promise.all(automationList(partnerList, newPlacements, type, jobList));
       }
     });
 }

--- a/server/jobs/offboarding/email.js
+++ b/server/jobs/offboarding/email.js
@@ -6,13 +6,15 @@ import { executeEmailAutomation } from '../helpers';
  * @desc Automates developer offboarding via email
  *
  * @param {Object} placement Placement record whose developer is to be offboarded
+ * @param {Object} partner Partner details to be used in the automation
  * @param {Object} automationId ID of the particular automation
  * @returns {Promise} Promise to return the result of the email automation executed
  */
-export default function emailOffboarding(placement, automationId) {
+export default function emailOffboarding(placement, partner, automationId) {
   return executeEmailAutomation(
     [sendSOPOffboardingMail, sendITOffboardingMail],
     placement,
+    partner.location,
     automationId,
   );
 }

--- a/server/jobs/offboarding/slack.js
+++ b/server/jobs/offboarding/slack.js
@@ -2,7 +2,6 @@
 import dotenv from 'dotenv';
 import { accessChannel } from '../../modules/slack/slackIntegration';
 import { createOrUpdateSlackAutomation } from '../../modules/automations';
-import { findPartnerById } from '../../modules/allocations';
 
 dotenv.config();
 const { SLACK_AVAILABLE_DEVS_CHANNEL_ID } = process.env;
@@ -11,15 +10,15 @@ const { SLACK_AVAILABLE_DEVS_CHANNEL_ID } = process.env;
  * @desc Automates developer offboarding on slack
  *
  * @param {Object} placement Placement record whose developer is to be offboarded
+ * @param {Object} partner Partner details to be used in the automation
  * @param {Object} automationId ID of the automation being carried out
  * @returns {Promise} Promise to return the created/updated slack automation
  */
-export default async function slackOffboarding(placement, automationId) {
-  const { fellow, client_id: partnerId } = placement;
+export default async function slackOffboarding(placement, { slackChannels }, automationId) {
+  const { fellow } = placement;
   accessChannel(fellow.email, SLACK_AVAILABLE_DEVS_CHANNEL_ID, 'invite').then(response => createOrUpdateSlackAutomation({ ...response, automationId }));
   try {
-    const { slackChannels } = await findPartnerById(partnerId, 'offboarding');
-    const response = await accessChannel(fellow.email, slackChannels.general, 'kick');
+    const response = await accessChannel(fellow.email, slackChannels.general.channelId, 'kick');
     return createOrUpdateSlackAutomation({ ...response, automationId });
   } catch (error) {
     return createOrUpdateSlackAutomation({

--- a/server/jobs/onboarding/email.js
+++ b/server/jobs/onboarding/email.js
@@ -6,9 +6,15 @@ import { executeEmailAutomation } from '../helpers';
  * @desc Automates developer onboarding on email
  *
  * @param {Object} placement Placement record whose developer is to be offboarded
+ * @param {Object} partner Partner details to be used in the automation
  * @param {Object} automationId ID of the particular automation
  * @returns {Promise} Promise to return the result of emailAutomation performed
  */
-const emailOnboarding = async (placement, automationId) => executeEmailAutomation([sendDevOnboardingMail, sendSOPOnboardingMail], placement, automationId);
+const emailOnboarding = async (placement, partner, automationId) => executeEmailAutomation(
+  [sendDevOnboardingMail, sendSOPOnboardingMail],
+  placement,
+  partner.location,
+  automationId,
+);
 
 export default emailOnboarding;

--- a/server/jobs/onboarding/freckle.js
+++ b/server/jobs/onboarding/freckle.js
@@ -7,19 +7,20 @@ import { createOrUpdateFreckleAutomation } from '../../modules/automations';
  * @desc Automates freckle developer onboarding.
  *
  * @param {Object} placement Placement record whose developer is to be onboarded
+ * @param {Object} partner Partner details to be used in the automation
  * @param {Object} automationId Result of automation job
  * @returns {Promise} Promise to return the result of partner upserted after automation
  */
-const freckleOnboarding = async (placement, automationId) => {
-  const { fellow, client_id: partnerId, client_name: partnerName } = placement;
+const freckleOnboarding = async (placement, partner, automationId) => {
+  const { fellow, client_id: partnerId } = placement;
   getOrCreateProject(placement.client_name).then(async (project) => {
     createOrUpdateFreckleAutomation({ ...project, automationId });
     assignProject(fellow.email, project.id).then(result => createOrUpdateFreckleAutomation({ ...result, automationId }));
-    return db.Partner.upsert({
-      partnerId,
-      name: partnerName,
-      freckleProjectId: project.id,
-    });
+    return db.Partner.findOne({ where: { partnerId } }).then(foundPartner => (foundPartner
+      ? foundPartner.update({
+        freckleProjectId: project.id,
+      })
+      : null));
   });
 };
 

--- a/server/jobs/onboarding/slack.js
+++ b/server/jobs/onboarding/slack.js
@@ -1,63 +1,49 @@
 import dotenv from 'dotenv';
-import db from '../../models';
-import { accessChannel, findOrCreatePartnerChannel } from '../../modules/slack/slackIntegration';
+import { accessChannel } from '../../modules/slack/slackIntegration';
 import { createOrUpdateSlackAutomation } from '../../modules/automations';
 
 dotenv.config();
 const { SLACK_AVAILABLE_DEVS_CHANNEL_ID, SLACK_RACK_CITY_CHANNEL_ID } = process.env;
 
+const automationData = channel => ({
+  status: 'success',
+  ...channel,
+  type: channel.channelProvision,
+  statusMessage: `${channel.channelName} slack channel ${channel.channelProvision}d`,
+});
+
 /**
- *@desc Perform onboarding automations for partner internal and general channels
+ * @desc Perform onboarding automations for partner internal and general channels
  *
- * @param {String} partnerName The name of the partner in the engagement
+ * @param {Object} partner The details of the partner in the engagement
  * @param {Object} fellow Details of the fellow to be onboarded in the engagement
  * @param {Number} automationId ID of the automation being carried out
  *
  * @returns {Promise} Promise to return an array of channelIds of the
  * channels(internal and general) used in automation
  */
-const onboardPartnerChannels = (partnerName, fellow, automationId) => Promise.all([
-  findOrCreatePartnerChannel({ name: partnerName }, 'internal', 'onboarding').then(
-    (internalChannel) => {
-      createOrUpdateSlackAutomation({ ...internalChannel, automationId });
-      return internalChannel.channelId;
-    },
-  ),
-  findOrCreatePartnerChannel({ name: partnerName }, 'general', 'onboarding').then(
-    (generalChannel) => {
-      createOrUpdateSlackAutomation({ ...generalChannel, automationId });
-      accessChannel(fellow.email, generalChannel.channelId, 'invite').then(result => createOrUpdateSlackAutomation({ ...result, automationId }));
-      return generalChannel.channelId;
-    },
-  ),
-]);
+const partnerChannelAutomations = ({ slackChannels }, fellow, automationId) => {
+  const internalAutomationData = automationData(slackChannels.internal);
+  const generalAutomationData = automationData(slackChannels.general);
+  createOrUpdateSlackAutomation({ ...internalAutomationData, automationId });
+  createOrUpdateSlackAutomation({ ...generalAutomationData, automationId });
+  accessChannel(fellow.email, slackChannels.general.channelId, 'invite').then(result => createOrUpdateSlackAutomation({ ...result, automationId }));
+};
 
 /**
  * @desc Automates developer onboarding on slack
  *
  * @param {object} placement Placement record whose developer is to be onboarded
+ * @param {Object} partner Partner details to be used in the automation
  * @param {Number} automationId ID of the automation being carried out
  *
  * @returns {Promise} Promise to return upserted partner details after automation
  */
-const slackOnBoarding = async (placement, automationId) => {
+const slackOnBoarding = async (placement, partner, automationId) => {
   const { fellow } = placement;
-  const { client_name: partnerName, client_id: partnerId } = placement;
   accessChannel(fellow.email, SLACK_AVAILABLE_DEVS_CHANNEL_ID, 'kick').then(response => createOrUpdateSlackAutomation({ ...response, automationId }));
   accessChannel(fellow.email, SLACK_RACK_CITY_CHANNEL_ID, 'invite').then(response => createOrUpdateSlackAutomation({ ...response, automationId }));
-  const [internalChannelId, generalChannelId] = await onboardPartnerChannels(
-    partnerName,
-    fellow,
-    automationId,
-  );
-  return db.Partner.upsert({
-    partnerId,
-    name: partnerName,
-    slackChannels: {
-      internal: internalChannelId,
-      general: generalChannelId,
-    },
-  });
+  partnerChannelAutomations(partner, fellow, automationId);
 };
 
 export default slackOnBoarding;

--- a/server/models/partner.js
+++ b/server/models/partner.js
@@ -6,6 +6,7 @@ export default (sequelize, DataTypes) => {
       name: DataTypes.STRING,
       partnerId: { type: DataTypes.STRING, allowNull: false, unique: true },
       slackChannels: DataTypes.JSON,
+      location: DataTypes.STRING,
     },
     {
       setterMethods: {

--- a/server/modules/allocations.js
+++ b/server/modules/allocations.js
@@ -25,14 +25,14 @@ const getPartnerfromAPI = async (partnerId) => {
 };
 
 /**
- *@desc Retrieve partner data from redisDB or Andela API
+ *@desc Retrieve partner data from database or Andela API
  *
  * @param {String} partnerId The ID of the partner to retrieve
  * @returns {Promise} Promise to return the partner's data
  */
 export const retrievePartner = async (partnerId) => {
-  const result = await redisdb.get(partnerId);
-  return !result ? getPartnerfromAPI(partnerId) : JSON.parse(result);
+  const result = await db.Partner.findOne({ where: { partnerId } });
+  return result || getPartnerfromAPI(partnerId);
 };
 
 /**
@@ -60,21 +60,40 @@ const generateInternalChannel = (newPartner, jobType) => {
  * @returns {Promise} Promise to return the data of the partner
  */
 export async function findPartnerById(partnerId, jobType) {
-  const partner = await db.Partner.findOne({ where: { partnerId } });
+  const partner = await redisdb.get(partnerId);
   if (!partner) {
     const newPartner = await retrievePartner(partnerId);
+    if (newPartner.slackChannels) {
+      redisdb.set(newPartner.partnerId, newPartner);
+      return newPartner;
+    }
     const [genChannel = {}, intChannel = {}] = await Promise.all([
       findOrCreatePartnerChannel(newPartner, 'general', jobType),
       generateInternalChannel(newPartner, jobType),
     ]);
     newPartner.slackChannels = {
-      general: genChannel.channelId,
-      internal: intChannel.channelId || newPartner.channel_id,
+      general: {
+        channelId: genChannel.channelId,
+        channelName: genChannel.channelName,
+        channelProvision: genChannel.type,
+      },
+      internal: intChannel.channelId
+        ? {
+          channelId: intChannel.channelId,
+          channelName: intChannel.channelName,
+          channelProvision: intChannel.type,
+        }
+        : {
+          channelId: newPartner.channel_id,
+          channelName: newPartner.channel_name,
+          channelProvision: 'retrieve',
+        },
     };
-    const [{ dataValues }] = await db.Partner.upsert(newPartner, { returning: true });
-    return dataValues;
+    const [{ dataValues: savedPartner }] = await db.Partner.upsert(newPartner, { returning: true });
+    redisdb.set(savedPartner.partnerId, JSON.stringify(savedPartner));
+    return savedPartner;
   }
-  return partner;
+  return JSON.parse(partner);
 }
 
 /**

--- a/server/modules/slack/slackIntegration.js
+++ b/server/modules/slack/slackIntegration.js
@@ -40,21 +40,6 @@ const createChannel = async (channelDetails) => {
 };
 
 /**
- *@desc Generate automation data using partner name and channelType
- *
- * @param {String} partnerName Name of the partner being onboarded or offboarded
- * @param {String} channelType The type of channel name to generate
- * @returns {Object} Details of the automation to be carried out
- */
-const automationData = (partnerName, channelType) => {
-  const channelName = makeChannelNames(partnerName, channelType);
-  // possibly refactor to eliminate this function entirely
-  return {
-    channelName,
-  };
-};
-
-/**
  * @desc Returns matched channels from a list of slack channels
  * @param {Array} channels List of channels from slack API to filter
  * @param {String} channelName The channel name to filter against
@@ -111,7 +96,10 @@ const findConditions = key => ({
   internal: key === '-int',
 });
 
+// if channel is an object, return the last 4 digits of channel.name,
+// if channel is string, return last 4 digits
 const searchKey = channel => (channel.name ? channel.name.slice(-4) : channel.slice(-4));
+
 /**
  *@desc Find exact matching channel from list of searched channels
  *
@@ -157,7 +145,7 @@ const matchedChannels = (channelData, partnerData) => ({
  * @returns {Promise} Promise to return an object containing details of the channel
  */
 export const findOrCreatePartnerChannel = async (partnerData, channelType, jobType) => {
-  const channelData = automationData(partnerData.name, channelType);
+  const channelData = { channelName: makeChannelNames(partnerData.name, channelType) };
   const partnerChannelGiven = Boolean(partnerData.channel_name && partnerData.channel_name.length);
   const result = await matchedChannels(channelData, partnerData)[partnerChannelGiven]();
   const existingChannel = await findOne(result, channelType);

--- a/server/modules/slack/slackIntegration.js
+++ b/server/modules/slack/slackIntegration.js
@@ -48,10 +48,9 @@ const createChannel = async (channelDetails) => {
  */
 const automationData = (partnerName, channelType) => {
   const channelName = makeChannelNames(partnerName, channelType);
+  // possibly refactor to eliminate this function entirely
   return {
-    slackUserId: null,
     channelName,
-    status: 'success',
   };
 };
 
@@ -164,16 +163,13 @@ export const findOrCreatePartnerChannel = async (partnerData, channelType, jobTy
   const existingChannel = await findOne(result, channelType);
   if (existingChannel) {
     return {
-      ...channelData,
+      type: 'retrieve',
       channelName: existingChannel.name,
       channelId: existingChannel.id,
-      type: 'retrieve',
-      statusMessage: `${existingChannel.name} slack channel retrieved`,
     };
   }
   if (jobType === 'onboarding') {
     channelData.type = 'create';
-    channelData.statusMessage = `${channelData.channelName} slack channel created`;
     return createChannel(channelData);
   }
   // Could not find partner channel for the offboarding

--- a/test/helpers/helpers.test.js
+++ b/test/helpers/helpers.test.js
@@ -6,13 +6,8 @@ import { automationData } from '../../server/jobs';
 import { redisdb } from '../../server/helpers/redis';
 import { getAndelaPartners } from '../../server/mockAndelaApi/mockPlacement';
 
-import * as allocation from '../../server/modules/allocations';
 import { samplePartner } from '../mocks/partners';
 import placements from '../mocks/allocations';
-
-const fakeFindPartner = sinon
-  .stub(allocation, 'findPartnerById')
-  .callsFake(() => samplePartner.data.values[0]);
 
 describe('Test that helper functions work as expected', () => {
   it('Ensures that response object contains data field', () => {
@@ -22,13 +17,13 @@ describe('Test that helper functions work as expected', () => {
   });
   it('Should return expected information about the partner', async () => {
     const placement = placements.data.values[0];
-    const mailInfo = await getMailInfo(placement);
+    const partnerLocation = 'San Francisco California, United States';
+    const mailInfo = getMailInfo(placement, partnerLocation);
     expect(mailInfo).to.be.an('object');
     expect(mailInfo.developerName).to.equal(placement.fellow.name);
     expect(mailInfo.partnerName).to.equal(placement.client_name);
-    expect(mailInfo.partnerLocation).to.equal(samplePartner.data.values[0].location);
+    expect(mailInfo.partnerLocation).to.equal(partnerLocation);
     expect(mailInfo.startDate).to.equal(placement.start_date);
-    fakeFindPartner.restore();
   });
   it('Should return expected automation data from placement details', async () => {
     const placement = placements.data.values[0];

--- a/test/modules/allocations.test.js
+++ b/test/modules/allocations.test.js
@@ -42,19 +42,8 @@ describe('Partner and Allocations Test Suite', async () => {
     // Mock successful request
     const fakeClientGet = sinon.stub(redisdb, 'get').callsFake(() => stringifiedPartner);
 
-    const partner = await resource.findPartnerById('ABCDEFZYXWVU');
+    const partner = await resource.findPartnerById('ABCDEFZYXWVU', 'onboarding');
     expect(partner.partnerId || partner.id).to.equal('ABCDEFZYXWVU');
-    fakeClientGet.restore();
-  });
-  it('Should throw error if radis encounters error getting partner data', async () => {
-    const errorMessage = 'Error retrieving data from radis';
-    const fakeClientGet = sinon.stub(redisdb, 'get').callsFake(() => new Error(errorMessage));
-
-    try {
-      await resource.findPartnerById('ABCDEFZYXWVU');
-    } catch (error) {
-      expect(error.message).to.equal(errorMessage);
-    }
     fakeClientGet.restore();
   });
   it('Should throw an error when no partner record was found', async () => {
@@ -69,7 +58,7 @@ describe('Partner and Allocations Test Suite', async () => {
     const fakeClientGet = sinon.stub(redisdb, 'get').callsFake(() => null);
     const fakeClientSet = sinon.stub(redisdb, 'set').callsFake(() => undefined);
     try {
-      await resource.findPartnerById('not-found-id');
+      await resource.findPartnerById('not-found-id', 'onboarding');
     } catch ({ response }) {
       expect(response.data.error).to.equal(response.data.error);
     }


### PR DESCRIPTION
#### What does this PR do?
Ensure partner pre-automation runs to get/update partner details before automation starts

#### Description of Task to be completed?
- refactor existing implementation to invoke `findPartnerById` before automation starts
- remove repeated invocations of `findPartnerById` within automations
- pass partner data to automation functions alongside placement object


#### Any background context you want to provide?
This is to ensure the automation runs efficiently, and that partner details is readily available during automations

#### What are the relevant pivotal tracker stories?
[#166582362](https://www.pivotaltracker.com/story/show/166582362)
