### PR TITLE
Change status of skipped automations marked as failed

### DIFF
--- a/server/modules/slack/slackIntegration.js
+++ b/server/modules/slack/slackIntegration.js
@@ -2,6 +2,8 @@ import { WebClient } from '@slack/client';
 import dotenv from 'dotenv';
 import makeChannelNames from '../../helpers/slackHelpers';
 import { redisdb } from '../../helpers/redis';
+import responseObject from "../utils";
+
 
 dotenv.config();
 const { SCAN_RANGE, REJECT_RATE_LIMIT, SLACK_TOKEN } = process.env;
@@ -209,13 +211,9 @@ export const accessChannel = async (email, channelId, context) => {
       statusMessage: `${email} ${contextObject[context].message} channel`,
     };
   } catch (error) {
-    return {
-      slackUserId: null,
-      channelId,
-      channelName: channelInfo && channelInfo.channel.name,
-      type: context,
-      status: 'failure',
-      statusMessage: `${error.message}`,
-    };
+    if (`${error.message}` === 'An API error occurred: not_in_channel' || 'An API error occurred: already_in_channel' || 'An API error occurred: not_in_group') {
+      return responseObject(channelId, channelInfo, error, 'success');
+    }
+    return responseObject(channelId, channelInfo, error, 'failure');
   }
 };

--- a/server/modules/utils.js
+++ b/server/modules/utils.js
@@ -1,0 +1,12 @@
+const responseObject = (IdOfChannel, channelInfo, error, statusMessage) => (
+  {
+    slackUserId: null,
+    channelId: IdOfChannel,
+    channelName: channelInfo && channelInfo.channel.name,
+    type: context,
+    status: statusMessage,
+    statusMessage: `${error.message}`,
+  }
+);
+
+export default responseObject;

--- a/test/endpoints/mockAndelapi.test.js
+++ b/test/endpoints/mockAndelapi.test.js
@@ -12,10 +12,6 @@ describe('Tests for mockAndelaApi endpoint\n', () => {
     const fakeUserList = sinon
       .stub(slackClient.users, 'list')
       .callsFake(() => new Promise(r => r(slackMocks.userList)));
-    const userEmails = slackMocks.userList.members.reduce(
-      (result, { profile: { email } }) => (email ? [...result, email] : result),
-      [],
-    );
     chai
       .request(app)
       .get(`/mock-api/placements?status=${status}`)


### PR DESCRIPTION
#### What does this PR do?

This PR changes the status of skipped automations from failure to success. Skipped automations are actions that have already been performed by a user.

Actions impacted by this PR include

* Inviting a user to a channel
* Removing a user from a channel

#### Description of Task to be completed?

Actions that have already been performed should be marked as skipped so they are not wrongly counted as an automation failure

#### How should this be manually tested?

* Clone the backend repo and install dependencies
* Run yarn start: dev and wait for automations to run. Automations that have already been performed manually, for example, adding a user to a channel or removing a user from a channel should be counted as a success

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?

#166907195

#### Postman Documentation
* N/A

#### Screenshots (If applicable)
*N/A