### PR TITLE
#167571330 Delete partner records

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint .",
     "migrations": "sequelize db:migrate",
     "reset-database": "npx redis-cli FLUSHALL && sequelize db:drop && sequelize db:create",
-    "docs": "./node_modules/.bin/jsdoc -c jsdoc.json"
+    "docs": "./node_modules/.bin/jsdoc -c jsdoc.json",
+    "delete-partners": "babel-node ./server/deletePartners.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/ash
-
+yarn delete-partners
 printf "\n\n======================================\n"
 printf "Run database migrations"
 printf "\n======================================\n\n"

--- a/server/deletePartners.js
+++ b/server/deletePartners.js
@@ -1,0 +1,5 @@
+import models from './models/index';
+
+models.sequelize.query('DELETE FROM "partners"').then(([, metadata]) => {
+  console.log('metadata>>>>>>>>', metadata);
+});


### PR DESCRIPTION
#### What does this PR do?
Delete all partner records in production database due to absence of location field

#### Description of Task to be completed?
- implement a one time script to delete partners since none has a location field
- create `delete-partners` script in `package.json` and add to pre-deployment shell script

#### How should this be manually tested?
1. On terminal, run command: `yarn delete-partners`
2. Check the terminal to view result of script execution
3. Check the database to confirm that partner records have been deleted successfully

#### Any background context you want to provide?
Currently, when migration is run in production, an error is thrown due to the `NOT NULL` constraint in the new location column defined in the migration to be executed. This conflicts with existing partner records which do not have location field

#### Any additional information to provide?
This implementation should be reverted after successful one time execution in production

#### What are the relevant pivotal tracker stories?
[#167571330](https://www.pivotaltracker.com/story/show/167571330)