### PR TITLE
#167486160 Protect routes on the backend to permit only authenticated users

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "http-proxy": "^1.17.0",
     "jsdoc": "^3.6.2",
     "jsonwebtoken": "^8.5.1",
+    "jwt-decode": "^2.2.0",
     "moment": "^2.24.0",
     "morgan": "^1.9.1",
     "ms": "^2.1.1",

--- a/server/helpers/authHelpers.js
+++ b/server/helpers/authHelpers.js
@@ -1,0 +1,4 @@
+import jwt from 'jsonwebtoken';
+
+// eslint-disable-next-line import/prefer-default-export
+export const generateToken = info => jwt.sign(info, process.env.JWT_KEY, { expiresIn: '1d' });

--- a/server/index.js
+++ b/server/index.js
@@ -27,7 +27,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 
 app.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept,authorization');
   next();
 });
 

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -9,15 +9,24 @@ const authenticateUser = async (req, res, next) => {
   const token = await req.headers.authorization;
   if (!token) return res.status(401).json({ success: false, error: 'No token provided' });
 
-  jwt.verify(
-    token,
-    setJwtKey(process.env.NODE_ENV),
-    (error, decodedToken) => {
-      if (error) return res.status(401).json({ success: false, error: 'Token is not valid' });
+  jwt.verify(token, setJwtKey(process.env.NODE_ENV), (error, decodedToken) => {
+    const userDetails = decodedToken;
+    const { UserInfo } = userDetails || {};
+    const roles = UserInfo ? UserInfo.roles : [];
+    const userRole = process.env.USER_ROLE;
+    const adminRoles = Object.keys(roles).includes(userRole);
+    if (adminRoles) {
+      if (error) return {};
       req.user = decodedToken;
       return next();
-    },
-  );
+    }
+    if (decodedToken === undefined) {
+      return res.status(401).json({ success: false, error: 'Token is not valid' });
+    }
+    return res
+      .status(403)
+      .json({ success: false, error: "the user doesn't have permissions to perform this action" });
+  });
   return false;
 };
 

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,24 @@
+import jwt from 'jsonwebtoken';
+
+export const setJwtKey = (nodeEnv) => {
+  if (nodeEnv === 'test') return process.env.JWT_KEY;
+  return Buffer.from(process.env.JWT_KEY, 'base64');
+};
+
+const authenticateUser = async (req, res, next) => {
+  const token = await req.headers.authorization;
+  if (!token) return res.status(401).json({ success: false, error: 'No token provided' });
+
+  jwt.verify(
+    token,
+    setJwtKey(process.env.NODE_ENV),
+    (error, decodedToken) => {
+      if (error) return res.status(401).json({ success: false, error: 'Token is not valid' });
+      req.user = decodedToken;
+      return next();
+    },
+  );
+  return false;
+};
+
+export default authenticateUser;

--- a/server/routes/automationRouter.js
+++ b/server/routes/automationRouter.js
@@ -1,11 +1,12 @@
 import express from 'express';
 import automationController from '../controllers/automationController';
 import automationStatusController from '../controllers/automationStatsController';
+import authenticateUser from '../middleware/auth';
 
 const router = express.Router();
 
-router.get('/', automationController.getAutomations);
-router.get('/stats', automationStatusController);
-router.get('/:id', automationController.retryAutomations);
+router.get('/', authenticateUser, automationController.getAutomations);
+router.get('/stats', authenticateUser, automationStatusController);
+router.get('/:id', authenticateUser, automationController.retryAutomations);
 
 export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -4,10 +4,11 @@ import workerStatus from '../controllers/workerStatus';
 import authApi from '../controllers/authController';
 import updatePartnerSlackChannels from '../controllers/partnerController';
 import { validatePartner } from '../validator';
+import authenticateUser from '../middleware/auth';
 
 export default (app) => {
-  app.put('/partners/:id', validatePartner, updatePartnerSlackChannels);
-  app.get('/worker-status', workerStatus);
+  app.put('/partners/:id', authenticateUser, validatePartner, updatePartnerSlackChannels);
+  app.get('/worker-status', authenticateUser, workerStatus);
   app.use('/mock-api', mockAndelAPI);
   app.use('/api/v1/automations', automationsAPI);
   app.use('/api/v1/auth', authApi);

--- a/test/endpoints/automations.test.js
+++ b/test/endpoints/automations.test.js
@@ -6,9 +6,13 @@ import {
   retryMockData, existingPlacement, slackAutomations, nokoAutomations, emailAutomations,
   offboardingMockData, partnerData,
 } from '../mocks/retryautomations';
+import { generateToken } from '../../server/helpers/authHelpers';
+import { userPayload } from '../mockData/userPayload';
 
 
 chai.use(chaiHttp);
+
+const userToken = generateToken(userPayload);
 
 describe('Tests for automation endpoints\n', () => {
   beforeEach('create mock db', async () => {
@@ -18,10 +22,40 @@ describe('Tests for automation endpoints\n', () => {
   afterEach(async () => {
     await models.Automation.destroy({ force: true, truncate: { cascade: true } });
   });
+
+  it('should return a 401 error if user does not supply token', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/automations')
+      .set('authorization', '')
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).to.have.status(401);
+        expect(res.body)
+          .to.have.property('error')
+          .to.equal('No token provided');
+        done();
+      });
+  });
+  it('should return a 401 error if user supplies an invalid token', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/automations')
+      .set('authorization', 'invalidToken')
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res).to.have.status(401);
+        expect(res.body)
+          .to.have.property('error')
+          .to.equal('Token is not valid');
+        done();
+      });
+  });
   it('Should return all data with a 200 response code', (done) => {
     chai
       .request(app)
       .get('/api/v1/automations')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -37,6 +71,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get('/api/v1/automations?page=1&limit=1')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -58,6 +93,7 @@ describe('Tests for automation endpoints\n', () => {
           1,
         ).toISOString()}&date[to]=${new Date(2019, 2, 10).toISOString()}`,
       )
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -75,6 +111,7 @@ describe('Tests for automation endpoints\n', () => {
       .get(
         `/api/v1/automations?page=1&limit=5&slackAutomation=success&date[to]=${new Date().toJSON()}`,
       )
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -96,6 +133,7 @@ describe('Tests for automation endpoints\n', () => {
           10,
         ).toISOString()}`,
       )
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -117,6 +155,7 @@ describe('Tests for automation endpoints\n', () => {
           1,
         ).toISOString()}&date[to]=${new Date(2019, 2, 10).toISOString()}`,
       )
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(400);
         expect(res.body)
@@ -129,6 +168,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get('/api/v1/automations?page=1&limit=5&type=onboarding')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -144,6 +184,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get('/api/v1/automations?page=1&limit=5&type=offboarding')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -159,6 +200,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get('/api/v1/automations?searchTerm=conroy')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -174,6 +216,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get('/api/v1/automations?searchTerm=val&searchBy=fellow')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -189,6 +232,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get('/api/v1/automations?searchTerm=conroy&searchBy=partner')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -204,6 +248,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get('/api/v1/automations/stats?duration=days')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -217,6 +262,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get(`/api/v1/automations/stats?duration=days&date=${new Date(2018, 4, 1).toISOString()}`)
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -230,6 +276,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get(`/api/v1/automations/stats?duration=weeks&date=${new Date(2018, 4, 1).toISOString()}`)
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -243,6 +290,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get(`/api/v1/automations/stats?duration=months&date=${new Date(2018, 4, 1).toISOString()}`)
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -256,6 +304,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get(`/api/v1/automations/stats?duration=years&date=${new Date(2018, 4, 1).toISOString()}`)
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -269,6 +318,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get(`/api/v1/automations/stats?duration=invalid&date=${new Date(2018, 4, 1).toISOString()}`)
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(400);
         expect(res.body)
@@ -281,6 +331,7 @@ describe('Tests for automation endpoints\n', () => {
     chai
       .request(app)
       .get('/api/v1/automations/stats?duration=days')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -318,6 +369,7 @@ describe(' Test for retrying automations', () => {
     chai
       .request(app)
       .get(`/api/v1/automations/${retryMockData.id}`)
+      .set('authorization', userToken)
       .end((err, res) => {
         if (err) done(err);
         expect(res).to.have.status(200);
@@ -331,6 +383,7 @@ describe(' Test for retrying automations', () => {
     chai
       .request(app)
       .get(`/api/v1/automations/${offboardingMockData.id}`)
+      .set('authorization', userToken)
       .end((err, res) => {
         if (err) done(err);
         expect(res).to.have.status(200);

--- a/test/endpoints/partner.test.js
+++ b/test/endpoints/partner.test.js
@@ -2,8 +2,12 @@ import chaiHttp from 'chai-http';
 import chai, { expect } from 'chai';
 import app from '../../server';
 import db from '../../server/models';
+import { generateToken } from '../../server/helpers/authHelpers';
+import { userPayload } from '../mockData/userPayload';
 
 chai.use(chaiHttp);
+
+const userToken = generateToken(userPayload);
 
 describe('Tests for PUT /partners/:id endpoint', () => {
   describe('Tests for request param.id in /partners/:id endpoint', () => {
@@ -11,6 +15,7 @@ describe('Tests for PUT /partners/:id endpoint', () => {
       chai
         .request(app)
         .put('/partners/invalid-id')
+        .set('authorization', userToken)
         .type('json')
         .send({})
         .end((err, res) => {
@@ -25,6 +30,7 @@ describe('Tests for PUT /partners/:id endpoint', () => {
       chai
         .request(app)
         .put('/partners/123456789123456789     ')
+        .set('authorization', userToken)
         .type('json')
         .send({})
         .end((err, res) => {
@@ -41,6 +47,7 @@ describe('Tests for PUT /partners/:id endpoint', () => {
       chai
         .request(app)
         .put('/partners/-KXGyJcC1oimjQgFj17U')
+        .set('authorization', userToken)
         .type('json')
         .send({
           invalidProperty: {},
@@ -61,6 +68,7 @@ describe('Tests for PUT /partners/:id endpoint', () => {
       chai
         .request(app)
         .put('/partners/-KXGyJcC1oimjQgFj17U')
+        .set('authorization', userToken)
         .type('json')
         .send({
           slackChannels: [],
@@ -83,6 +91,7 @@ describe('Tests for PUT /partners/:id endpoint', () => {
       chai
         .request(app)
         .put('/partners/-KXGyJcC1oimjQgFj17U')
+        .set('authorization', userToken)
         .type('json')
         .send({
           slackChannels: {},
@@ -104,6 +113,7 @@ describe('Tests for PUT /partners/:id endpoint', () => {
       chai
         .request(app)
         .put('/partners/-KXGyJcC1oimjQgFj17U')
+        .set('authorization', userToken)
         .type('json')
         .send({
           slackChannels: {
@@ -132,6 +142,7 @@ describe('Tests for PUT /partners/:id endpoint', () => {
       chai
         .request(app)
         .put('/partners/-KXGyJcC1oimjQgFj17U')
+        .set('authorization', userToken)
         .type('json')
         .send({
           slackChannels: {
@@ -163,6 +174,7 @@ describe('Tests for PUT /partners/:id endpoint', () => {
       chai
         .request(app)
         .put('/partners/-KXGyJcC1oimjQgFj17U')
+        .set('authorization', userToken)
         .type('json')
         .send({
           slackChannels: {
@@ -199,6 +211,7 @@ describe('Tests for PUT /partners/:id endpoint', () => {
       chai
         .request(app)
         .put('/partners/-KXGyJcC1oimjQgFj18t')
+        .set('authorization', userToken)
         .type('json')
         .send({
           slackChannels: {
@@ -252,6 +265,7 @@ describe('Tests for PUT /partners/:id endpoint', () => {
         chai
           .request(app)
           .put(`/partners/${partnerData.partnerId}`)
+          .set('authorization', userToken)
           .type('json')
           .send(channelUpdate)
           .end((err, res) => {

--- a/test/endpoints/workerStatus.test.js
+++ b/test/endpoints/workerStatus.test.js
@@ -3,9 +3,14 @@ import chai, { expect } from 'chai';
 import sinon from 'sinon';
 import app from '../../server';
 import client from '../../server/helpers/redis';
+import { generateToken } from '../../server/helpers/authHelpers';
+import { userPayload } from '../mockData/userPayload';
 
 chai.use(chaiHttp);
+
+const userToken = generateToken(userPayload);
 const fakeStatus = ['"2019-01-09T09:59:53.045Z"', 'Successfull', '2'];
+
 describe('Tests for worker status endpoints\n', () => {
   it('Should return worker status with a 200 status code', (done) => {
     const fakeClient = sinon
@@ -15,6 +20,7 @@ describe('Tests for worker status endpoints\n', () => {
     chai
       .request(app)
       .get('/worker-status')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(200);
         expect(res.body)
@@ -37,6 +43,7 @@ describe('Tests for worker status endpoints\n', () => {
     chai
       .request(app)
       .get('/worker-status')
+      .set('authorization', userToken)
       .end((err, res) => {
         expect(res).to.have.status(500);
         expect(res.body)

--- a/test/middleware/auth.test.js
+++ b/test/middleware/auth.test.js
@@ -1,0 +1,13 @@
+import { setJwtKey } from '../../server/middleware/auth';
+
+describe('setJwtKey', () => {
+  it('should set the right key during test environment', () => {
+    const decodingKey = setJwtKey('test');
+    expect(decodingKey).to.equal(process.env.JWT_KEY);
+  });
+
+  it('should set the right key during devlopment / production environment', () => {
+    const decodingKey = setJwtKey('development');
+    expect(Buffer.isBuffer(decodingKey)).to.equal(true);
+  });
+});

--- a/test/mockData/userPayload.js
+++ b/test/mockData/userPayload.js
@@ -1,0 +1,19 @@
+export const userPayload = {
+  UserInfo: {
+    id: '678t7t7657t6t8722',
+    name: 'Sammy Lee',
+    email: 'lee_dee@andela.com',
+    picture: 'pixel-perfect-picture.jpg',
+    roles: {
+      Fellow: '-uiioip3oo2hjhioj',
+      Andelan: '-iye98yik3j9jud',
+    },
+  },
+};
+
+export const invalidUserPayload = {
+  name: 'Sammy Lee',
+  email: 'lee_dee@andela.com',
+  picture: 'pixel-perfect-picture.jpg',
+  email_verified: true,
+};


### PR DESCRIPTION
#### What does this PR do?
- Protect routes to permit only authenticated users

#### Description of Task to be completed?
- Implement a `jwt` method to verify provided token for user access
- Modify tests to work with authentication

#### How should this be manually tested?
* Checkout to the branch ```ft-protect-routes-167486160```.
* In your `.env` file, add a variable with title `JWT_KEY` and set the value to the JWT_KEY provided in the dev slack channel.
* In your `.env` file, add a variable with title `USER_ROLE` and set the value to `Andelan`
* Start the back-end server with ```npm run start:dev```.
* Visit the route `http://localhost:8000/api/v1/automations`. You will be prompted with a message that you provided no token.
* To access the route, sign in from your `front-end`, copy the `jwt-token` from your cookies and add the value to your authorizations `header` in postman. With this, you can successfully access the protected routes.
* For the frontend branch checkout to the branch called `ft-authorize-user-based-on-roles-164598501` and try logging into the app with your andela email.
* To test if the user roles are checked against, in the backend, change the `USER_ROLE` value to a role that doesn't exist and you will get a response that says you have have the permissions to perform a certain task on the backend.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[167486160](https://www.pivotaltracker.com/story/show/167486160)

#### Postman Documentation


#### Screenshots (If applicable)