### PR TITLE
#167701221 Fix undefined context error thrown during automation

### DIFF
--- a/server/modules/utils.js
+++ b/server/modules/utils.js
@@ -1,12 +1,10 @@
-const responseObject = (IdOfChannel, channelInfo, error, statusMessage) => (
-  {
-    slackUserId: null,
-    channelId: IdOfChannel,
-    channelName: channelInfo && channelInfo.channel.name,
-    type: context,
-    status: statusMessage,
-    statusMessage: `${error.message}`,
-  }
-);
+const responseObject = (IdOfChannel, channelInfo, error, statusMessage, type) => ({
+  slackUserId: null,
+  channelId: IdOfChannel,
+  channelName: channelInfo && channelInfo.channel.name,
+  type,
+  status: statusMessage,
+  statusMessage: `${error.message}`,
+});
 
 export default responseObject;


### PR DESCRIPTION
#### What does this PR do?
Fix undefined context error by ensuring slackAutomation `type` is passed as argument to  `responseObject`

#### Description of Task to be completed?
- pass `type` argument to responseObject

#### How should this be manually tested?
1. On terminal, run command: `yarn start:dev` to launch the app
2. Wait for automation to be executed
3. Observe that error: `context is not defined`, no longer throws on the terminal

#### Any background context you want to provide?
When there is an unsuccessful slack automation, details of the slack automation is not successfully persisted to database due to an undefined context error thrown in responseObject function before data database transaction. As a result of this, details of unsuccessful slack automations are not recorded

#### What are the relevant pivotal tracker stories?
[#167701221](https://www.pivotaltracker.com/story/show/167701221)
