### PR TITLE
#168061772: Create an endpoint for engagement trends

### DIFF
--- a/server/helpers/dateHelpers.js
+++ b/server/helpers/dateHelpers.js
@@ -46,3 +46,63 @@ export function isValidStartDate({ endDate = moment(), startDate = moment().subt
   // check if both date from and to are provided
   return { dateFrom, dateTo };
 }
+
+/**
+ * Define the difference between the start and end dates
+ *
+ * @param {object} duration - represents whether the query is days/months/years
+ * @param {boolean} trends - represents if the request is for trends or stats endpoint
+ *
+ * @returns {number} - returns a date value
+ */
+const dateSubtractor = (duration, trends) => {
+  let date;
+  if (duration === 'days') {
+    switch (trends) {
+      case true:
+        date = 30;
+        return date;
+      default:
+        date = 0;
+        return date;
+    }
+  }
+  date = 1;
+  return date;
+};
+
+/**
+ * check if the duration selected is days/months/years
+ *
+ * @param {object} duration - check whether the query is days/months/years
+ *
+ * @returns {object} returns an error message
+ */
+export const checkDuration = (duration) => {
+  if (duration !== 'days' && duration !== 'weeks' && duration !== 'months' && duration !== 'years') {
+    const error = 'invalid duration input';
+    return error;
+  }
+  return false;
+};
+
+/**
+ * Return the start and end dates for a specific time period
+ *
+ * @param {object} date - date query from the request object
+ * @param {boolean} trends - represents whether the request is for trends or stats endpoint
+ * @param {number} duration - represents either days/months/years
+ *
+ * @returns {object} response of the start and end dates respectively
+ */
+export const validateDate = (date, trends, duration) => {
+  const dateStart = date
+    ? moment(date).subtract(dateSubtractor(duration, trends), duration).format('YYYY-MM-DD')
+    : moment().subtract(dateSubtractor(duration, trends), duration).format('YYYY-MM-DD');
+
+  const dateEnd = date
+    ? moment(date).format('YYYY-MM-DD')
+    : moment().format('YYYY-MM-DD');
+
+  return { dateStart, dateEnd };
+};

--- a/server/routes/dashboardRouter.js
+++ b/server/routes/dashboardRouter.js
@@ -1,8 +1,10 @@
 import express from 'express';
 import dashboardController from '../controllers/dashboardController';
+import authenticateUser from '../middleware/auth';
 
 const router = express.Router();
 
 router.get('/upselling-partners', dashboardController.getUpsellingPartners);
+router.get('/trends', authenticateUser, dashboardController.getEngagementTends);
 
 export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -7,6 +7,7 @@ import updatePartnerSlackChannels from '../controllers/partnerController';
 import { validatePartner } from '../validator';
 import authenticateUser from '../middleware/auth';
 
+
 export default (app) => {
   app.put('/partners/:id', authenticateUser, validatePartner, updatePartnerSlackChannels);
   app.get('/worker-status', authenticateUser, workerStatus);

--- a/test/endpoints/engagementTrends.test.js
+++ b/test/endpoints/engagementTrends.test.js
@@ -1,0 +1,86 @@
+import chaiHttp from 'chai-http';
+import chai, { expect } from 'chai';
+import app from '../../server';
+import models from '../../server/models';
+import { existingPlacement } from '../mocks/retryautomations';
+import { generateToken } from '../../server/helpers/authHelpers';
+import { userPayload } from '../mockData/userPayload';
+
+
+chai.use(chaiHttp);
+
+const userToken = generateToken(userPayload);
+
+describe('Tests for engagement trends endpoint\n', () => {
+  beforeEach('create mock db', async () => {
+    await models.Automation.bulkCreate(existingPlacement);
+  });
+
+  afterEach(async () => {
+    await models.Automation.destroy({ force: true, truncate: { cascade: true } });
+  });
+
+  it('should return stats of engagement trends', (done) => {
+    chai
+      .request(app)
+      .get('/api/v1/dashboard/trends?duration=days')
+      .set('authorization', userToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        done();
+      });
+  });
+  it('should return stats of engagement trends of a given date', (done) => {
+    chai
+      .request(app)
+      .get(`/api/v1/dashboard/trends?duration=days&date=${new Date(2019, 4, 1).toISOString()}`)
+      .set('authorization', userToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        done();
+      });
+  });
+  it('should return stats of engagement trends of a given week', (done) => {
+    chai
+      .request(app)
+      .get(`/api/v1/dashboard/trends?duration=weeks&date=${new Date(2019, 4, 1).toISOString()}`)
+      .set('authorization', userToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        done();
+      });
+  });
+  it('should return stats of engagement trends of a given month', (done) => {
+    chai
+      .request(app)
+      .get(`/api/v1/dashboard/trends?duration=months&date=${new Date(2019, 4, 1).toISOString()}`)
+      .set('authorization', userToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        done();
+      });
+  });
+  it('should return stats of engagement trends of a given year', (done) => {
+    chai
+      .request(app)
+      .get(`/api/v1/dashboard/trends?duration=years&date=${new Date(2019, 4, 1).toISOString()}`)
+      .set('authorization', userToken)
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        done();
+      });
+  });
+  it('should return an error when an invalid duration is input', (done) => {
+    chai
+      .request(app)
+      .get(`/api/v1/dashboard/trends?duration=invalid&date=${new Date(2019, 4, 1).toISOString()}`)
+      .set('authorization', userToken)
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body)
+          .to.have.property('error')
+          .to.equal('invalid duration input');
+        done();
+      });
+  });
+});

--- a/test/modules/slackIntegration.spec.js
+++ b/test/modules/slackIntegration.spec.js
@@ -28,7 +28,6 @@ describe('Slack Integration Test Suite', async () => {
     Object.keys(fakeSlackClient).forEach(fake => fakeSlackClient[fake].resetHistory());
     createOrUpdateSlackAutomation.resetHistory();
   });
-
   it('Should create internal slack channels and save the automation to DB', async () => {
     const { data } = onboardingAllocations;
     const { client_name: partnerName } = data.values[0];


### PR DESCRIPTION
#### What does this PR do?
- Fetch data representing the engagement trends

#### Description of Task to be completed?
- Fetch data representing the engagement trends

#### How should this be manually tested?
1. Checkout to `ft-engagement-trends` branch
2. On terminal, run command `yarn start:dev`
3. Query results using `/api/v1/dashboard/trends?duration=days` for default and change the duration to `weeks`/ `months`/`years` for the different periods.

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#168061772 

#### Postman Documentation
N/A

#### Screenshots (If applicable)
<img width="1440" alt="Screen Shot 2019-09-17 at 3 09 25 PM" src="https://user-images.githubusercontent.com/9901086/65040493-3243c980-d95d-11e9-9bce-6a5dabcacaf9.png">


